### PR TITLE
Support rest args in native function macro

### DIFF
--- a/crates/steel-core/src/primitives.rs
+++ b/crates/steel-core/src/primitives.rs
@@ -421,7 +421,7 @@ impl<'a> PrimitiveAsRef<'a> for &'a SteelString {
         if let SteelVal::StringV(s) = val {
             Ok(s)
         } else {
-            crate::stop!(ConversionError => format!("Cannot convert steel value: {} to steel string", val))
+            crate::stop!(TypeMismatch => format!("Cannot convert steel value: {} to steel string", val))
         }
     }
 }

--- a/crates/steel-core/src/primitives.rs
+++ b/crates/steel-core/src/primitives.rs
@@ -12,7 +12,7 @@ mod ports;
 pub mod process;
 pub mod random;
 mod streams;
-mod strings;
+pub mod strings;
 mod symbols;
 pub mod time;
 pub mod transducers;
@@ -36,7 +36,6 @@ pub use meta_ops::MetaOperations;
 pub use nums::NumOperations;
 pub use ports::port_module;
 pub use streams::StreamOperations;
-pub use strings::StringOperations;
 pub use symbols::SymbolOperations;
 pub use vectors::VectorOperations;
 

--- a/crates/steel-core/src/primitives/lists.rs
+++ b/crates/steel-core/src/primitives/lists.rs
@@ -1,5 +1,5 @@
 use crate::steel_vm::{
-    builtin::{BuiltInModule, DocTemplate, MarkdownDoc},
+    builtin::{BuiltInModule, DocTemplate},
     vm::{apply, VmContext, APPLY_DOC},
 };
 use crate::{

--- a/crates/steel-core/src/primitives/lists.rs
+++ b/crates/steel-core/src/primitives/lists.rs
@@ -24,7 +24,6 @@ declare_const_ref_functions! {
 
 declare_const_mut_ref_functions! {
     CONS => cons,
-    // FIRST => first,
     REST => rest,
     CDR => cdr,
     APPEND => append,

--- a/crates/steel-core/src/primitives/strings.rs
+++ b/crates/steel-core/src/primitives/strings.rs
@@ -15,7 +15,7 @@ fn char_upcase(c: char) -> char {
 ///
 /// Strings in Steel are immutable, fixed length arrays of characters. They are heap allocated,
 /// and are implemented under the hood as referenced counted rust `Strings`.
-#[steel_derive::define_module(name = "steel/strings")]
+// #[steel_derive::define_module(name = "steel/strings")]
 pub fn string_module() -> BuiltInModule {
     let mut module = BuiltInModule::new("steel/strings");
     module
@@ -72,7 +72,7 @@ pub fn to_string(args: &[SteelVal]) -> Result<SteelVal> {
 /// ```scheme
 /// > (string->symbol "FooBar") ;; => 'FooBar
 /// ```
-#[function(name = "string->symbol")]
+#[function(name = "string->symbol", constant = true)]
 pub fn string_to_symbol(value: SteelString) -> SteelVal {
     SteelVal::SymbolV(value)
 }

--- a/crates/steel-core/src/rvals.rs
+++ b/crates/steel-core/src/rvals.rs
@@ -332,6 +332,29 @@ pub(crate) trait PrimitiveAsRef<'a>: Sized {
     fn primitive_as_ref(val: &'a SteelVal) -> Result<Self>;
 }
 
+pub struct RestArgs<T: FromSteelVal>(pub Vec<T>);
+
+impl<T: FromSteelVal> RestArgs<T> {
+    pub fn new(args: Vec<T>) -> Self {
+        RestArgs(args)
+    }
+
+    pub fn from_slice(args: &[SteelVal]) -> Result<Self> {
+        args.iter()
+            .map(|x| T::from_steelval(x))
+            .collect::<Result<Vec<_>>>()
+            .map(RestArgs)
+    }
+}
+
+impl<T: FromSteelVal> std::ops::Deref for RestArgs<T> {
+    type Target = [T];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
 mod private {
 
     use std::any::Any;
@@ -1197,6 +1220,13 @@ impl SteelVal {
         match self {
             Self::ListV(v) => Ok(v),
             _ => Err(err()),
+        }
+    }
+
+    pub fn list(&self) -> Option<&List<SteelVal>> {
+        match self {
+            Self::ListV(l) => Some(l),
+            _ => None,
         }
     }
 

--- a/crates/steel-core/src/steel_vm/mod.rs
+++ b/crates/steel-core/src/steel_vm/mod.rs
@@ -14,5 +14,5 @@ pub mod register_fn;
 mod test_util;
 #[cfg(test)]
 mod tests;
-mod transducers;
+pub(crate) mod transducers;
 pub(crate) mod vm;

--- a/crates/steel-core/src/steel_vm/primitives.rs
+++ b/crates/steel-core/src/steel_vm/primitives.rs
@@ -5,7 +5,7 @@ use super::{
     cache::WeakMemoizationTable,
     engine::Engine,
     register_fn::RegisterFn,
-    vm::{apply, get_test_mode, list_modules, set_test_mode, VmCore, APPLY_DOC},
+    vm::{get_test_mode, list_modules, set_test_mode, VmCore},
 };
 use crate::{
     parser::span::Span,
@@ -16,9 +16,7 @@ use crate::{
         hashmaps::{HM_CONSTRUCT, HM_GET, HM_INSERT},
         hashsets::hashset_module,
         lists::{
-            UnRecoverableResult, APPEND_DOC, CAR_DOC, CDR_DOC, CONS_DOC, FIRST_DOC, IS_EMPTY_DOC,
-            LAST_DOC, LENGTH_DOC, LIST_DOC, LIST_REF_DOC, RANGE_DOC, REST_DOC, REVERSE_DOC,
-            SECOND_DOC, THIRD_DOC,
+            list_module, UnRecoverableResult,
         },
         nums::quotient,
         port_module,
@@ -456,55 +454,6 @@ pub static SANDBOXED_MODULES: &str = r#"
 
 // static MAP_MODULE: Lazy<BuiltInModule> = Lazy::new(hashmap);
 // static SET_MODULE: Lazy<BuiltInModule> = Lazy::new(hashset);
-
-pub(crate) const TEST_APPLY: SteelVal = SteelVal::BuiltIn(apply);
-
-fn list_module() -> BuiltInModule {
-    let mut module = BuiltInModule::new("steel/lists");
-
-    // Register the doc for the module
-    module.register_doc("steel/lists", crate::primitives::lists::LIST_MODULE_DOC);
-
-    // Grab a raw handle to a list
-    module.register_native_fn(
-        "%raw-list",
-        crate::primitives::lists::new,
-        Arity::AtLeast(0),
-    );
-
-    module
-        .register_value_with_doc(LIST, crate::primitives::lists::LIST, LIST_DOC)
-        .register_value_with_doc(CONS, crate::primitives::lists::CONS, CONS_DOC)
-        .register_value_with_doc(RANGE, crate::primitives::lists::RANGE, RANGE_DOC)
-        .register_value_with_doc(LENGTH, crate::primitives::lists::LENGTH, LENGTH_DOC)
-        .register_value_with_doc("last", crate::primitives::lists::LAST, LAST_DOC)
-        .register_value_with_doc("empty?", crate::primitives::lists::IS_EMPTY, IS_EMPTY_DOC)
-        .register_value_with_doc(CAR, crate::primitives::lists::CAR, CAR_DOC)
-        .register_value_with_doc(FIRST, crate::primitives::lists::CAR, FIRST_DOC)
-        .register_value_with_doc(CDR, crate::primitives::lists::CDR, CDR_DOC)
-        .register_value_with_doc(REST, crate::primitives::lists::REST, REST_DOC)
-        .register_value_with_doc(APPEND, crate::primitives::lists::APPEND, APPEND_DOC)
-        .register_value_with_doc(REVERSE, crate::primitives::lists::REVERSE, REVERSE_DOC)
-        .register_value_with_doc("list-ref", crate::primitives::lists::LIST_REF, LIST_REF_DOC)
-        .register_value("try-list-ref", crate::primitives::lists::TRY_LIST_REF)
-        .register_value("list->string", crate::primitives::lists::LIST_TO_STRING)
-        .register_value("push-back", crate::primitives::lists::PUSH_BACK)
-        .register_value("pair?", crate::primitives::lists::PAIR)
-        // .register_value("test-push-back", crate::primitives::alternative_list::PU)
-        // .register_value("test-map", crate::primitives::lists::TEST_MAP)
-        // TODO move this to somewhere better than here
-        .register_value_with_doc("apply", TEST_APPLY, APPLY_DOC)
-        // .register_value("transduce", crate::steel_vm::transducers::TRANSDUCE)
-        // .register_value("execute", crate::steel_vm::transducers::EXECUTE)
-        .register_value("transduce", crate::steel_vm::transducers::TRANSDUCE)
-        .register_fn("second", crate::primitives::lists::second)
-        .register_fn("third", crate::primitives::lists::third);
-
-    module.register_doc("second", SECOND_DOC);
-    module.register_doc("third", THIRD_DOC);
-
-    module
-}
 
 fn vector_module() -> BuiltInModule {
     let mut module = BuiltInModule::new("steel/vectors");

--- a/crates/steel-core/src/steel_vm/primitives.rs
+++ b/crates/steel-core/src/steel_vm/primitives.rs
@@ -15,9 +15,7 @@ use crate::{
         hashmaps::hashmap_module,
         hashmaps::{HM_CONSTRUCT, HM_GET, HM_INSERT},
         hashsets::hashset_module,
-        lists::{
-            list_module, UnRecoverableResult,
-        },
+        lists::{list_module, UnRecoverableResult},
         nums::quotient,
         port_module,
         process::process_module,

--- a/crates/steel-core/src/tests/mod.rs
+++ b/crates/steel-core/src/tests/mod.rs
@@ -96,6 +96,7 @@ test_harness_success! {
     stack_state,
     stack_struct,
     stack_test_with_contract,
+    string_append,
     transducer_over_streams,
     trie_sort,
     y_combinator,

--- a/crates/steel-core/src/tests/mod.rs
+++ b/crates/steel-core/src/tests/mod.rs
@@ -65,6 +65,7 @@ test_harness_success! {
     delim_control_n,
     define_normal,
     dfs,
+    empty,
     fib,
     generator,
     generic_execution_dropping,

--- a/crates/steel-core/src/tests/success/empty.scm
+++ b/crates/steel-core/src/tests/success/empty.scm
@@ -1,0 +1,2 @@
+(assert! (empty? '()))
+(assert! (not (empty? (list 10 20 30 40))))

--- a/crates/steel-core/src/tests/success/string_append.scm
+++ b/crates/steel-core/src/tests/success/string_append.scm
@@ -1,0 +1,3 @@
+(assert! (equal? (string-append) ""))
+(assert! (equal? (string-append "foo") "foo"))
+(assert! (equal? (string-append "foo" "bar") "foobar"))

--- a/crates/steel-derive/src/lib.rs
+++ b/crates/steel-derive/src/lib.rs
@@ -8,7 +8,8 @@ use std::collections::HashMap;
 use proc_macro::TokenStream;
 use quote::{quote, ToTokens};
 use syn::{
-    punctuated::Punctuated, Data, DeriveInput, Expr, ExprLit, FnArg, Ident, ItemFn, Lit, Meta, ReturnType, Signature, Type,
+    punctuated::Punctuated, Data, DeriveInput, Expr, ExprLit, FnArg, Ident, ItemFn, Lit, Meta,
+    ReturnType, Signature, Type,
 };
 
 #[proc_macro_derive(Steel)]

--- a/crates/steel-derive/src/lib.rs
+++ b/crates/steel-derive/src/lib.rs
@@ -3,11 +3,13 @@ extern crate proc_macro2;
 #[macro_use]
 extern crate syn;
 extern crate quote;
+use std::collections::HashMap;
+
 use proc_macro::TokenStream;
 use quote::{quote, ToTokens};
 use syn::{
     punctuated::Punctuated, Data, DeriveInput, Expr, ExprLit, FnArg, Ident, ItemFn, Lit, Meta,
-    ReturnType, Signature, Type,
+    PathArguments, ReturnType, Signature, Type,
 };
 
 #[proc_macro_derive(Steel)]
@@ -46,6 +48,24 @@ fn parse_key_value_pair(args: &Punctuated<Meta, Token![,]>) -> (String, String) 
     }
 
     panic!("Expected a key value pair");
+}
+
+fn parse_key_value_pairs(args: &Punctuated<Meta, Token![,]>) -> HashMap<String, String> {
+    let mut map = HashMap::new();
+
+    for nested_meta in args.iter() {
+        if let Meta::NameValue(n) = nested_meta {
+            let key = n.path.get_ident().unwrap().to_string();
+            if let Expr::Lit(ExprLit {
+                lit: Lit::Str(s), ..
+            }) = &n.value
+            {
+                map.insert(key, s.value());
+            }
+        }
+    }
+
+    map
 }
 
 fn parse_doc_comment(input: ItemFn) -> Option<String> {
@@ -92,6 +112,114 @@ fn parse_doc_comment(input: ItemFn) -> Option<String> {
     Some(trimmed.join("\n"))
 }
 
+#[proc_macro_attribute]
+pub fn define_module(
+    args: proc_macro::TokenStream,
+    input: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    let args = parse_macro_input!(args with Punctuated::<Meta, Token![,]>::parse_terminated);
+    let input = parse_macro_input!(input as ItemFn);
+    let keyword_map = parse_key_value_pairs(&args);
+
+    let value = keyword_map
+        .get("name")
+        .expect("native definition requires a name!");
+
+    let sign: Signature = input.sig.clone();
+
+    let maybe_doc_comments = parse_doc_comment(input.clone());
+
+    let function_name = sign.ident.clone();
+
+    if let Some(doc_comments) = maybe_doc_comments {
+        quote! {
+            pub fn #function_name() -> BuiltInModule {
+                #input
+
+                let mut module = #function_name();
+
+                module.register_doc(#value, crate::steel_vm::builtin::MarkdownDoc(#doc_comments));
+
+                module
+            }
+        }
+        .into()
+    } else {
+        quote! {
+            #input
+        }
+        .into()
+    }
+}
+
+#[proc_macro_attribute]
+pub fn native(
+    args: proc_macro::TokenStream,
+    input: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    let args = parse_macro_input!(args with Punctuated::<Meta, Token![,]>::parse_terminated);
+
+    let keyword_map = parse_key_value_pairs(&args);
+
+    let value = keyword_map
+        .get("name")
+        .expect("native definition requires a name!");
+
+    let arity_number = keyword_map
+        .get("arity")
+        .expect("native definition requires an arity");
+
+    let arity_number: syn::Expr =
+        syn::parse_str(arity_number).expect("Unable to parse arity definition");
+
+    let input = parse_macro_input!(input as ItemFn);
+
+    let modified_input = input.clone();
+    let sign: Signature = input.clone().sig;
+
+    let maybe_doc_comments = parse_doc_comment(input);
+    let function_name = sign.ident.clone();
+
+    let doc_name = Ident::new(
+        &(function_name.to_string().to_uppercase() + "_DEFINITION"),
+        sign.ident.span(),
+    );
+
+    let definition_struct = if let Some(doc) = maybe_doc_comments {
+        quote! {
+            pub const #doc_name: crate::steel_vm::builtin::NativeFunctionDefinition = crate::steel_vm::builtin::NativeFunctionDefinition {
+                name: #value,
+                func: #function_name,
+                arity: crate::steel_vm::builtin::Arity::#arity_number,
+                doc: Some(crate::steel_vm::builtin::MarkdownDoc(#doc))
+            };
+        }
+    } else {
+        quote! {
+            pub const #doc_name: crate::steel_vm::builtin::NativeFunctionDefinition = crate::steel_vm::builtin::NativeFunctionDefinition {
+                name: #value,
+                func: #function_name,
+                arity: crate::steel_vm::builtin::Arity::#arity_number,
+                doc: None
+            };
+        }
+    };
+
+    let output = quote! {
+        // Not sure why, but it says this is unused even when generating functions
+        // marked as pub
+        #[allow(dead_code)]
+        #modified_input
+
+        #definition_struct
+    };
+
+    // Uncomment this to see the generated code
+    // eprintln!("{}", output.to_string());
+
+    return output.into();
+}
+
 // See REmacs : https://github.com/remacs/remacs/blob/16b6fb9319a6d48fbc7b27d27c3234990f6718c5/rust_src/remacs-macros/lib.rs#L17-L161
 // TODO: Pass the new name in to this function
 #[proc_macro_attribute]
@@ -106,13 +234,13 @@ pub fn function(
 
     let input = parse_macro_input!(input as ItemFn);
 
-    let mut modified_input = input.clone();
+    let modified_input = input.clone();
     // let ident = input.sig.ident.clone();
     let sign: Signature = input.clone().sig;
 
     let maybe_doc_comments = parse_doc_comment(input);
 
-    modified_input.attrs = Vec::new();
+    // modified_input.attrs = Vec::new();
 
     // let sign: Signature = input.clone().sig;
 
@@ -147,11 +275,36 @@ pub fn function(
 
     let mut type_vec: Vec<Box<Type>> = Vec::new();
 
-    for arg in sign.inputs {
+    let mut rest_arg_generic_inner_type = false;
+
+    for (i, arg) in sign.inputs.iter().enumerate() {
         if let FnArg::Typed(pat_ty) = arg.clone() {
+            if let Type::Path(p) = pat_ty.ty.as_ref() {
+                let primary_type = p.path.segments.iter().last();
+                if let Some(ty) = primary_type {
+                    match ty.ident.to_token_stream().to_string().as_str() {
+                        "RestArgs" => {
+                            if rest_arg_generic_inner_type {
+                                panic!("There cannot be multiple `RestArg`s for a given function.")
+                            }
+
+                            if i != sign.inputs.len() - 1 {
+                                panic!(
+                                    "The rest argument must be the last argument in the function."
+                                )
+                            }
+                            rest_arg_generic_inner_type = true;
+                        }
+                        _ => {}
+                    }
+                }
+            }
+
             type_vec.push(pat_ty.ty);
         }
     }
+
+    // panic!("{:?}", type_vec);
 
     let arity_number = type_vec.len();
 
@@ -182,12 +335,18 @@ pub fn function(
         sign.ident.span(),
     );
 
+    let arity_exactness = if rest_arg_generic_inner_type {
+        quote! { Exact }
+    } else {
+        quote! { AtLeast }
+    };
+
     let definition_struct = if let Some(doc) = maybe_doc_comments {
         quote! {
             pub const #doc_name: crate::steel_vm::builtin::NativeFunctionDefinition = crate::steel_vm::builtin::NativeFunctionDefinition {
                 name: #value,
                 func: #copied_function_name,
-                arity: crate::steel_vm::builtin::Arity::Exact(#arity_number),
+                arity: crate::steel_vm::builtin::Arity::#arity_exactness(#arity_number),
                 doc: Some(crate::steel_vm::builtin::MarkdownDoc(#doc))
             };
         }
@@ -196,11 +355,72 @@ pub fn function(
             pub const #doc_name: crate::steel_vm::builtin::NativeFunctionDefinition = crate::steel_vm::builtin::NativeFunctionDefinition {
                 name: #value,
                 func: #copied_function_name,
-                arity: crate::steel_vm::builtin::Arity::Exact(#arity_number),
+                arity: crate::steel_vm::builtin::Arity::#arity_exactness(#arity_number),
                 doc: None
             };
         }
     };
+
+    // If we have a rest arg, we need to modify passing in values to pass in a slice to the remaining
+    // values in the
+    if rest_arg_generic_inner_type {
+        let mut conversion_functions = conversion_functions.collect::<Vec<_>>();
+        let arg_enumerate = arg_enumerate.clone();
+        let mut arg_index = arg_enumerate
+            .clone()
+            .map(|(i, _)| quote! { #i })
+            .collect::<Vec<_>>();
+
+        if let Some(last) = arg_index.last_mut() {
+            *last = quote! { #last.. };
+        }
+
+        let arity_number = arity_number - 1;
+
+        if let Some(last) = conversion_functions.last_mut() {
+            *last = quote! { from_slice };
+        }
+
+        let function_name = sign.ident.clone();
+
+        let output = quote! {
+            // Not sure why, but it says this is unused even when generating functions
+            // marked as pub
+            #[allow(dead_code)]
+            #modified_input
+
+            #definition_struct
+
+            pub fn #copied_function_name(args: &[SteelVal]) -> std::result::Result<SteelVal, crate::rerrs::SteelErr> {
+
+                use crate::rvals::{IntoSteelVal, FromSteelVal, PrimitiveAsRef};
+
+                if args.len() < #arity_number {
+                    crate::stop!(ArityMismatch => format!("{} expected {} arguments, got {}", #value, #arity_number.to_string(), args.len()))
+                }
+
+                let res = #function_name(
+                    #(
+                        // TODO: Distinguish reference types here if possible - make a special implementation
+                        // for builtin pointer types here to distinguish them
+                        <#arg_type>::#conversion_functions(&args[#arg_index])
+                            .map_err(|mut err| {
+                                err.prepend_message(#function_names_with_colon);
+                                err.set_kind(crate::rerrs::ErrorKind::TypeMismatch);
+                                err
+                            } )?,
+                    )*
+                );
+
+                #ret_val
+            }
+        };
+
+        // Uncomment this to see the generated code
+        // eprintln!("{}", output.to_string());
+
+        return output.into();
+    }
 
     let output = quote! {
         // Not sure why, but it says this is unused even when generating functions
@@ -213,7 +433,6 @@ pub fn function(
         pub fn #copied_function_name(args: &[SteelVal]) -> std::result::Result<SteelVal, crate::rerrs::SteelErr> {
 
             use crate::rvals::{IntoSteelVal, FromSteelVal, PrimitiveAsRef};
-
 
             if args.len() != #arity_number {
                 crate::stop!(ArityMismatch => format!("{} expected {} arguments, got {}", #value, #arity_number.to_string(), args.len()))

--- a/crates/steel-derive/src/lib.rs
+++ b/crates/steel-derive/src/lib.rs
@@ -8,8 +8,7 @@ use std::collections::HashMap;
 use proc_macro::TokenStream;
 use quote::{quote, ToTokens};
 use syn::{
-    punctuated::Punctuated, Data, DeriveInput, Expr, ExprLit, FnArg, Ident, ItemFn, Lit, Meta,
-    PathArguments, ReturnType, Signature, Type,
+    punctuated::Punctuated, Data, DeriveInput, Expr, ExprLit, FnArg, Ident, ItemFn, Lit, Meta, ReturnType, Signature, Type,
 };
 
 #[proc_macro_derive(Steel)]
@@ -311,7 +310,7 @@ pub fn function(
                 let primary_type = p.path.segments.iter().last();
                 if let Some(ty) = primary_type {
                     match ty.ident.to_token_stream().to_string().as_str() {
-                        "RestArgs" => {
+                        "RestArgs" | "RestArgsIter" => {
                             if rest_arg_generic_inner_type {
                                 panic!("There cannot be multiple `RestArg`s for a given function.")
                             }


### PR DESCRIPTION
Now the last argument in the arguments can be a rest argument.

Take for example the following:

```rust
/// Concatenates all of the given strings into one
///
/// (string-append strs...) -> string?
///
/// * strs ... : string?
///
/// # Examples
/// ```scheme
/// > (string-append) ;; => ""
/// > (string-append "foo" "bar") ;; => "foobar"
// ```
#[function(name = "string-append")]
pub fn string_append(rest: RestArgs<SteelString>) -> SteelVal {
    let accumulated = rest
        .0
        .into_iter()
        .fold("".to_string(), |accum, next| accum + next.as_str());

    SteelVal::StringV(accumulated.into())
}
```

However, this will allocate a new `Vec<T>` for the rest. The alternative implementation will use an iterator over the rest args, making it optional to allocate:

```rust
/// Concatenates all of the given strings into one
///
/// (string-append strs...) -> string?
///
/// * strs ... : string?
///
/// # Examples
/// ```scheme
/// > (string-append) ;; => ""
/// > (string-append "foo" "bar") ;; => "foobar"
// ```
#[function(name = "string-append")]
pub fn string_append(mut rest: RestArgsIter<'_, &SteelString>) -> Result<SteelVal> {
    rest.0
        .try_fold("".to_string(), |accum, next| Ok(accum + next?.as_str()))
        .map(|x| SteelVal::StringV(x.into()))
}
```

Closes #64 