### PR TITLE
implementation of command new

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,8 @@ enum EmitAction {
     },
     /// Test the module
     Test { default_file: Option<String> },
+    /// Create basic project folder in current dir
+    New { folder_name: String },
     /// Generate the documentation for a file
     Doc { default_file: Option<PathBuf> },
 }
@@ -94,6 +96,18 @@ pub fn run(clap_args: Args) -> Result<(), Box<dyn Error>> {
             ..
         } => {
             todo!()
+        }
+        Args {
+            action: Some(EmitAction::New { folder_name }),
+            ..
+        } => {
+            let folder_creation_result = create_project_folder(&folder_name);
+            if let Err(e) = folder_creation_result {
+                eprintln!("{e}");
+                return Ok(());
+            }
+            println!("project folder `{}` created", &folder_name);
+            Ok(())
         }
 
         Args {
@@ -196,6 +210,48 @@ pub fn run(clap_args: Args) -> Result<(), Box<dyn Error>> {
             Ok(())
         }
     }
+}
+
+fn create_project_folder(folder_name: &String) -> Result<(), std::io::Error> {
+    fs::create_dir(folder_name)?;
+    let manifest_content = format!(
+        r#"(define package-name "{folder_name}")
+(define version "0.1.0")
+
+(define dependencies '())
+"#
+    );
+    fs::write(format!("{folder_name}/cog.scm"), manifest_content)?;
+    let main_content = r#"(require "mysum.scm")
+
+(define (main a b)
+    (begin
+        ( displayln "hello world!" )
+        ( display a )
+        ( display " + " )
+        ( display b )
+        ( display " = " )
+        ( displayln (mysum a b) )
+    ))
+
+(main 1 1)
+"#;
+    fs::write(format!("{folder_name}/main.scm"), main_content)?;
+    let mysum_content = r#"(provide mysum)
+
+(define (mysum a b) (+ a b) )
+"#;
+    fs::write(format!("{folder_name}/mysum.scm"), mysum_content)?;
+    let mysum_test_content = r#"(require "steel/tests/unit-test.scm" (for-syntax "steel/tests/unit-test.scm"))
+(require "mysum.scm")
+
+(test-module
+  "mysum"
+  (check-equal? "my sum works!" 3 (mysum 1 2))
+)
+"#;
+    fs::write(format!("{folder_name}/mysum-test.scm"), mysum_test_content)?;
+    Ok(())
 }
 
 pub fn finish(result: Result<(), std::io::Error>) -> ! {


### PR DESCRIPTION
![image](https://github.com/mattwparas/steel/assets/30749948/a275c71b-48a8-4123-8099-15e379ed5710)

The steel new command shares its purpose with tools like cargo new and stack new - it creates the initial boilerplate to kickstart programming.

There are various considerations to ponder:

    What should the folder structure look like? (e.g., src, lib, tests...)
    Should we offer a main manifest (like package.json or cargo.toml)?
    Do we encourage separate test files or embedding tests within source files?
    Is main.scm fixed as the root, or can it be configured in the manifest?
    Any other considerations?

In this implementation, I've made certain choices: a flat file structure, an example test file, main.scm as the root, and cogs.scm as the manifest.
```sh
$ steel new myproject
$ tree myproject
myproject
├── cog.scm
├── main.scm
├── mysum.scm
└── mysum-test.scm
``` 
I don't have strong preferences and usually go with defaults I like. But I'm open to making changes and improvements, also in the code. 
Please feel free to suggest any improvements.