### PR TITLE
Case insensitive string functions

### DIFF
--- a/cogs/r5rs.scm
+++ b/cogs/r5rs.scm
@@ -373,6 +373,14 @@
 (check-equal? "string <=, true" #t (string<=? "a" "aa"))
 (check-equal? "string <=, same string" #t (string<=? "a" "a"))
 
+(check-equal? "case-insensitive string-equality with constructor, equal" #t (string-ci=? "A" (string #\a)))
+(check-equal? "case-insensitive string-equality with constructor, not equal" #f (string-ci=? "A" (string #\b)))
+(check-equal? "case-insensitive string<, true" #t (string-ci<? "A" "aa"))
+(check-equal? "case-insensitive string<, false" #f (string-ci<? "AA" "a"))
+(check-equal? "case-insensitive string<, same strings" #f (string-ci<? "A" "a"))
+(check-equal? "case-insensitive string <=, true" #t (string-ci<=? "A" "aa"))
+(check-equal? "case-insensitive string <=, same string" #t (string-ci<=? "A" "a"))
+
 (skip-compile (check-equal #t (string=? "a" (make-string 1 #\a)))
               (check-equal #f (string=? "a" (make-string 1 #\b))))
 

--- a/cogs/r5rs.scm
+++ b/cogs/r5rs.scm
@@ -372,6 +372,11 @@
 (check-equal? "string<, same strings" #f (string<? "a" "a"))
 (check-equal? "string <=, true" #t (string<=? "a" "aa"))
 (check-equal? "string <=, same string" #t (string<=? "a" "a"))
+(check-equal? "string>, true" #t (string>? "aa" "a"))
+(check-equal? "string>, false" #f (string>? "a" "aa"))
+(check-equal? "string>, same strings" #f (string>? "a" "a"))
+(check-equal? "string >=, true" #t (string>=? "aa" "a"))
+(check-equal? "string >=, same string" #t (string>=? "a" "a"))
 
 (check-equal? "case-insensitive string-equality with constructor, equal" #t (string-ci=? "A" (string #\a)))
 (check-equal? "case-insensitive string-equality with constructor, not equal" #f (string-ci=? "A" (string #\b)))
@@ -380,6 +385,11 @@
 (check-equal? "case-insensitive string<, same strings" #f (string-ci<? "A" "a"))
 (check-equal? "case-insensitive string <=, true" #t (string-ci<=? "A" "aa"))
 (check-equal? "case-insensitive string <=, same string" #t (string-ci<=? "A" "a"))
+(check-equal? "case-insensitive string>, true" #t (string-ci>? "aa" "A"))
+(check-equal? "case-insensitive string>, false" #f (string-ci>? "a" "AA"))
+(check-equal? "case-insensitive string>, same strings" #f (string-ci>? "A" "a"))
+(check-equal? "case-insensitive string >=, true" #t (string-ci>=? "aa" "A"))
+(check-equal? "case-insensitive string >=, same string" #t (string-ci>=? "a" "A"))
 
 (skip-compile (check-equal #t (string=? "a" (make-string 1 #\a)))
               (check-equal #f (string=? "a" (make-string 1 #\b))))

--- a/crates/steel-core/src/primitives/strings.rs
+++ b/crates/steel-core/src/primitives/strings.rs
@@ -44,6 +44,10 @@ pub fn string_module() -> BuiltInModule {
         .register_native_fn_definition(STRING_CI_LESS_THAN_DEFINITION)
         .register_native_fn_definition(STRING_LESS_THAN_EQUAL_TO_DEFINITION)
         .register_native_fn_definition(STRING_CI_LESS_THAN_EQUAL_TO_DEFINITION)
+        .register_native_fn_definition(STRING_GREATER_THAN_DEFINITION)
+        .register_native_fn_definition(STRING_CI_GREATER_THAN_DEFINITION)
+        .register_native_fn_definition(STRING_GREATER_THAN_EQUAL_TO_DEFINITION)
+        .register_native_fn_definition(STRING_CI_GREATER_THAN_EQUAL_TO_DEFINITION)
         .register_native_fn_definition(STRING_CONSTRUCTOR_DEFINITION)
         .register_native_fn_definition(STRING_TO_NUMBER_DEFINITION)
         .register_native_fn_definition(NUMBER_TO_STRING_DEFINITION)
@@ -163,6 +167,26 @@ pub fn string_less_than(left: &SteelString, right: &SteelString) -> bool {
 #[function(name = "string-ci<?", constant = true)]
 pub fn string_ci_less_than(left: &SteelString, right: &SteelString) -> bool {
     left.to_lowercase() < right.to_lowercase()
+}
+
+#[function(name = "string>=?", constant = true)]
+pub fn string_greater_than_equal_to(left: &SteelString, right: &SteelString) -> bool {
+    left >= right
+}
+
+#[function(name = "string-ci>=?", constant = true)]
+pub fn string_ci_greater_than_equal_to(left: &SteelString, right: &SteelString) -> bool {
+    left.to_lowercase() >= right.to_lowercase()
+}
+
+#[function(name = "string>?", constant = true)]
+pub fn string_greater_than(left: &SteelString, right: &SteelString) -> bool {
+    left > right
+}
+
+#[function(name = "string-ci>?", constant = true)]
+pub fn string_ci_greater_than(left: &SteelString, right: &SteelString) -> bool {
+    left.to_lowercase() > right.to_lowercase()
 }
 
 #[function(name = "string=?", constant = true)]

--- a/crates/steel-core/src/primitives/strings.rs
+++ b/crates/steel-core/src/primitives/strings.rs
@@ -39,8 +39,11 @@ pub fn string_module() -> BuiltInModule {
         .register_native_fn_definition(STRING_REF_DEFINITION)
         .register_native_fn_definition(SUBSTRING_DEFINITION)
         .register_native_fn_definition(STRING_EQUALS_DEFINITION)
+        .register_native_fn_definition(STRING_CI_EQUALS_DEFINITION)
         .register_native_fn_definition(STRING_LESS_THAN_DEFINITION)
+        .register_native_fn_definition(STRING_CI_LESS_THAN_DEFINITION)
         .register_native_fn_definition(STRING_LESS_THAN_EQUAL_TO_DEFINITION)
+        .register_native_fn_definition(STRING_CI_LESS_THAN_EQUAL_TO_DEFINITION)
         .register_native_fn_definition(STRING_CONSTRUCTOR_DEFINITION)
         .register_native_fn_definition(STRING_TO_NUMBER_DEFINITION)
         .register_native_fn_definition(NUMBER_TO_STRING_DEFINITION)
@@ -147,14 +150,29 @@ pub fn string_less_than_equal_to(left: &SteelString, right: &SteelString) -> boo
     left <= right
 }
 
+#[function(name = "string-ci<=?", constant = true)]
+pub fn string_ci_less_than_equal_to(left: &SteelString, right: &SteelString) -> bool {
+    left.to_lowercase() <= right.to_lowercase()
+}
+
 #[function(name = "string<?", constant = true)]
 pub fn string_less_than(left: &SteelString, right: &SteelString) -> bool {
     left < right
 }
 
+#[function(name = "string-ci<?", constant = true)]
+pub fn string_ci_less_than(left: &SteelString, right: &SteelString) -> bool {
+    left.to_lowercase() < right.to_lowercase()
+}
+
 #[function(name = "string=?", constant = true)]
 pub fn string_equals(left: &SteelString, right: &SteelString) -> bool {
     left == right
+}
+
+#[function(name = "string-ci=?", constant = true)]
+pub fn string_ci_equals(left: &SteelString, right: &SteelString) -> bool {
+    left.to_lowercase() == right.to_lowercase()
 }
 
 #[function(name = "string-ref", constant = true)]


### PR DESCRIPTION
Re https://github.com/mattwparas/steel/issues/65

Does not include [string-ci>?](https://docs.racket-lang.org/reference/strings.html#%28def._%28%28quote._~23~25kernel%29._string-ci~3e~3f%29%29), [string-ci>=?](https://docs.racket-lang.org/reference/strings.html#%28def._%28%28quote._~23~25kernel%29._string-ci~3e~3d~3f%29%29) because Steel does not include [string>?](https://docs.racket-lang.org/reference/strings.html#%28def._%28%28quote._~23~25kernel%29._string~3e~3f%29%29),[string>=?](https://docs.racket-lang.org/reference/strings.html#%28def._%28%28quote._~23~25kernel%29._string~3e~3d~3f%29%29). I can add them if you want?

I was originally deferring the case insensitive checks to the non-ci versions, but since they accept a `SteelString` and `to_lowercase()` returns a `String`, it seemed not worth re-wrapping the types (?) and I just repeated the comparison code.