### PR TITLE
implementation of command test

### DIFF
--- a/cogs/test-runner.scm
+++ b/cogs/test-runner.scm
@@ -1,4 +1,4 @@
-(require "fs/fs.scm")
+(require "steel/fs/fs.scm")
 
 (define shared-engine (Engine::new))
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ enum EmitAction {
         default_file: Option<PathBuf>,
         arguments: Vec<String>,
     },
-    /// Test the module
+    /// Tests the module - only tests modules which provide values
     Test { default_file: Option<String> },
     /// Generate the documentation for a file
     Doc { default_file: Option<PathBuf> },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,12 +95,24 @@ pub fn run(clap_args: Args) -> Result<(), Box<dyn Error>> {
 
         Args {
             default_file: None,
-            action: Some(EmitAction::Test { default_file: _ }),
+            action: Some(EmitAction::Test { default_file }),
             ..
         } => {
-            todo!()
+            let file_or_current_dir: String = default_file.unwrap_or(".".to_string());
+            if let Some(path) = PathBuf::from(file_or_current_dir).to_str() {
+                let mut vm = Engine::new();
+                vm.register_value(
+                    "std::env::args",
+                    steel::SteelVal::ListV(vec![path.to_string().into()].into()),
+                );
+                let test_script = include_str!("../cogs/test-runner.scm");
+                if let Err(e) = vm.run(test_script) {
+                    e.emit_result(path, &test_script);
+                    return Err(Box::new(e));
+                }
+            }
+            Ok(())
         }
-
         Args {
             default_file: None,
             action: Some(EmitAction::Doc {


### PR DESCRIPTION
![image](https://github.com/mattwparas/steel/assets/30749948/36f126d0-2122-4f63-8424-46be1841c7a8)
![image](https://github.com/mattwparas/steel/assets/30749948/110af9c0-963e-45a6-a587-ff2f86bb340f)

The "test command" serves to run the test runner and gather feedback from the test suite concerning the overall status of our program.

Different programming languages and ecosystems use a range of approaches to tackle this task. Some use external tools, while others integrate it into their toolchains. Certain ecosystems rely on third-party libraries, and there are those that aim to standardize the process as much as possible.

This current implementation is limited to utilizing/embedding ([this](https://github.com/mattwparas/steel/blob/master/cogs/test-runner.scm)) the existing testing system and providing a user-friendly interface through the Steel CLI. This enables running tests in the module's working directory or choosing specific tests to run.

we can using the command in this ways:
```sh
steel test   # run the tests in the current directory
steel test . # equal to above
steel test contracts/contract-test.scm # run only test of the selected file
```

### note
- To make this work, I had to adjust the import path of  [test-runner.scm](https://github.com/mattwparas/steel/blob/master/cogs/test-runner.scm), but it doesn't appear to be a concern.
- To ensure that the external file test works correctly (now they must `provide` something to works), we must address the tree-shaking issue we previously discussed #84 .

I welcome all feedback and suggestions for improvement
