### PR TITLE
fix flake and dev shell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3192,10 +3192,6 @@ dependencies = [
 [[package]]
 name = "steel-values"
 version = "0.1.0"
-dependencies = [
- "im-lists",
- "im-rc",
-]
 
 [[package]]
 name = "steel-webrequests"

--- a/flake.nix
+++ b/flake.nix
@@ -45,8 +45,11 @@
       packages.steel = steel;
       legacyPackages = packages;
       defaultPackage = packages.steel;
-      devShell = pkgs.mkShell {
-        buildInputs = with pkgs; [cargo];
+      devShell = with pkgs; mkShell {
+        buildInputs = [cargo openssl] ++ lib.optionals stdenv.isDarwin [darwin.apple_sdk.frameworks.Security];
+        nativeBuildInputs = [
+          pkg-config
+        ];
       };
     });
 }


### PR DESCRIPTION
Just updates the Cargo.lock so the flake builds and updates the devshell to include openssl