### PR TITLE
Add make-string primitive, enable associated test cases

### DIFF
--- a/cogs/r5rs.scm
+++ b/cogs/r5rs.scm
@@ -422,8 +422,8 @@
 (check-equal? "case-insensitive string >=, true" #t (string-ci>=? "aa" "A"))
 (check-equal? "case-insensitive string >=, same string" #t (string-ci>=? "a" "A"))
 
-(check-equal #t (string=? "a" (make-string 1 #\a)))
-(check-equal #f (string=? "a" (make-string 1 #\b)))
+(check-equal? "make-string creates single character string 'a' correctly" #t (string=? "a" (make-string 1 #\a)))
+(check-equal? "make-string with character 'b' does not create string 'a'" #f (string=? "a" (make-string 1 #\b)))
 
 (check-equal? "string-append with empty string" "abc" (string-append "abc" ""))
 

--- a/cogs/r5rs.scm
+++ b/cogs/r5rs.scm
@@ -387,6 +387,11 @@
 (check-equal? "substring just the first character" "a" (substring "abc" 0 1))
 (check-equal? "substring a larger chunk" "bc" (substring "abc" 1 3))
 
+(check-equal? "Basic functionality of make-string" "aaa" (make-string 3 #\a))
+(check-equal? "make-string with no character" "\0\0\0" (make-string 3))
+(check-equal? "make-string with zero length" "" (make-string 0))
+(check-equal? "make-string with multiple additional characters" "error" (make-string 3 #\a #\b))
+
 (check-equal? "string-equality with constructor, equal" #t (string=? "a" (string #\a)))
 (check-equal? "string-equality with constructor, not equal" #f (string=? "a" (string #\b)))
 (check-equal? "string<, true" #t (string<? "a" "aa"))
@@ -417,8 +422,8 @@
 (check-equal? "case-insensitive string >=, true" #t (string-ci>=? "aa" "A"))
 (check-equal? "case-insensitive string >=, same string" #t (string-ci>=? "a" "A"))
 
-(skip-compile (check-equal #t (string=? "a" (make-string 1 #\a)))
-              (check-equal #f (string=? "a" (make-string 1 #\b))))
+(check-equal #t (string=? "a" (make-string 1 #\a)))
+(check-equal #f (string=? "a" (make-string 1 #\b)))
 
 (check-equal? "string-append with empty string" "abc" (string-append "abc" ""))
 

--- a/crates/steel-core/src/primitives/strings.rs
+++ b/crates/steel-core/src/primitives/strings.rs
@@ -40,6 +40,7 @@ pub fn string_module() -> BuiltInModule {
         .register_native_fn_definition(TRIM_START_MATCHES_DEFINITION)
         .register_native_fn_definition(STRING_REF_DEFINITION)
         .register_native_fn_definition(SUBSTRING_DEFINITION)
+        .register_native_fn_definition(MAKE_STRING_DEFINITION)
         .register_native_fn_definition(STRING_EQUALS_DEFINITION)
         .register_native_fn_definition(STRING_CI_EQUALS_DEFINITION)
         .register_native_fn_definition(STRING_LESS_THAN_DEFINITION)
@@ -229,6 +230,20 @@ pub fn substring(value: &SteelString, i: usize, j: usize) -> Result<SteelVal> {
     }
 
     Ok(SteelVal::StringV(value[i..j].into()))
+}
+
+#[function(name = "make-string")]
+pub fn make_string(k: usize, mut c: RestArgsIter<'_, char>) -> Result<SteelVal> {
+    // If the char is there, we want to take it
+    let char = c.next();
+
+    // We want the iterator to be exhaused
+    if let Some(next) = c.next() {
+        stop!(ArityMismatch => format!("make-string expected 1 or 2 arguments, got an additional argument {}", next?))
+    }
+
+    let c = char.unwrap_or(Ok('\0'))?;
+    Ok((0..k).into_iter().map(|_| c).collect::<String>().into())
 }
 
 /// Concatenatives all of the inputs to their string representation, separated by spaces.


### PR DESCRIPTION
I have added the `make-string` primitive, as discussed in https://github.com/mattwparas/steel/issues/114

I have enabled the skipped tests in `cogs/r5rs.scm` as well and also added a few new test cases 

Please let me know if this is good enough 