### PR TITLE
Add better support for native threads

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,39 @@
+name: Deploy
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # To push a branch 
+      pull-requests: write  # To create a PR from that branch
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Install latest mdbook
+      run: |
+        tag=$(curl 'https://api.github.com/repos/rust-lang/mdbook/releases/latest' | jq -r '.tag_name')
+        url="https://github.com/rust-lang/mdbook/releases/download/${tag}/mdbook-${tag}-x86_64-unknown-linux-gnu.tar.gz"
+        mkdir mdbook
+        curl -sSL $url | tar -xz --directory=./mdbook
+        echo `pwd`/mdbook >> $GITHUB_PATH
+    - name: Deploy GitHub Pages
+      run: |
+        cd docs
+        mdbook build
+        git worktree add gh-pages
+        git config user.name "Deploy from CI"
+        git config user.email ""
+        cd gh-pages
+        # There are benchmarks stored in dev/bench/ that we would like to
+        # keep around. Otherwise, this just adds the book as a separate
+        # directory.
+        rm -rf book
+        mv ../book/ .
+        git add .
+        git commit -m "Deploy $GITHUB_SHA to gh-pages"
+        git push --force --set-upstream origin gh-pages

--- a/crates/steel-core/src/compiler/constants.rs
+++ b/crates/steel-core/src/compiler/constants.rs
@@ -54,12 +54,16 @@ impl ConstantMap {
         SerializableConstantMap(self.to_bytes().unwrap())
     }
 
-    pub fn to_serializable_vec(&self) -> Vec<SerializableSteelVal> {
+    pub fn to_serializable_vec(
+        &self,
+        serializer: &mut std::collections::HashMap<usize, SerializableSteelVal>,
+        visited: &mut std::collections::HashSet<usize>,
+    ) -> Vec<SerializableSteelVal> {
         self.values
             .borrow()
             .iter()
             .cloned()
-            .map(into_serializable_value)
+            .map(|x| into_serializable_value(x, serializer, visited))
             .collect::<Result<_>>()
             .unwrap()
     }
@@ -73,8 +77,6 @@ impl ConstantMap {
     // }
 
     pub fn from_vec(vec: Vec<SteelVal>) -> ConstantMap {
-        // ConstantMap(Rc::new(RefCell::new(vec)))
-
         ConstantMap {
             map: Rc::new(RefCell::new(
                 vec.clone()

--- a/crates/steel-core/src/steel_vm/vm/threads.rs
+++ b/crates/steel-core/src/steel_vm/vm/threads.rs
@@ -183,13 +183,17 @@ fn spawn_thread_result(ctx: &mut VmCore, args: &[SteelVal]) -> Result<SteelVal> 
         }
     };
 
+    let constants = time!("Constant map serialization", {
+        let constants = ctx
+            .thread
+            .constant_map
+            .to_serializable_vec(&mut initial_map, &mut visited);
+
+        constants
+    });
+
     let thread = MovableThread {
-        constants: time!(
-            "Constant map serialization",
-            ctx.thread
-                .constant_map
-                .to_serializable_vec(&mut initial_map, &mut visited)
-        ),
+        constants,
 
         // Void in this case, is a poisoned value. We need to trace the closure
         // (and all of its references) - to find any / all globals that _could_ be

--- a/crates/steel-core/src/steel_vm/vm/threads.rs
+++ b/crates/steel-core/src/steel_vm/vm/threads.rs
@@ -479,7 +479,7 @@ pub fn threading_module() -> BuiltInModule {
                 .recv()
                 .map_err(|e| SteelErr::new(ErrorKind::Generic, e.to_string()))?;
 
-            let mut heap = Heap::new();
+            let mut heap = Heap::new_empty();
             let mut fake_heap = HashMap::new();
             let mut patcher = HashMap::new();
             let mut built_functions = HashMap::new();
@@ -504,7 +504,7 @@ pub fn threading_module() -> BuiltInModule {
 
                 let value = receiver.try_recv();
 
-                let mut heap = Heap::new();
+                let mut heap = Heap::new_empty();
                 let mut fake_heap = HashMap::new();
                 let mut patcher = HashMap::new();
                 let mut built_functions = HashMap::new();
@@ -526,6 +526,5 @@ pub fn threading_module() -> BuiltInModule {
             },
         )
         .register_fn("thread::current/id", || std::thread::current().id());
-    // .register_fn("current-os!", || std::env::consts::OS);
     module
 }

--- a/crates/steel-core/src/tests/mod.rs
+++ b/crates/steel-core/src/tests/mod.rs
@@ -2,8 +2,6 @@ use crate::steel_vm::engine::Engine;
 
 fn generate_asserting_machine() -> Engine {
     let vm = Engine::new();
-    // vm.compile_and_run_raw_program(PRELUDE).unwrap();
-    // vm.compile_and_run_raw_program(CONTRACTS).unwrap();
     vm
 }
 

--- a/crates/steel-core/src/values/closed.rs
+++ b/crates/steel-core/src/values/closed.rs
@@ -230,6 +230,17 @@ impl Heap {
         }
     }
 
+    pub fn new_empty() -> Self {
+        Heap {
+            memory: Vec::new(),
+            vectors: Vec::new(),
+            count: 0,
+            threshold: GC_THRESHOLD,
+            mark_and_sweep_queue: Vec::new(),
+            maybe_memory_size: 0,
+        }
+    }
+
     // #[inline(always)]
     // pub fn memory(&mut self) -> &mut Vec<HeapValue> {
     //     match self.current {

--- a/crates/steel-core/src/values/closed.rs
+++ b/crates/steel-core/src/values/closed.rs
@@ -258,6 +258,15 @@ impl Heap {
         HeapRef { inner: weak_ptr }
     }
 
+    pub fn allocate_without_collection<'a>(&mut self, value: SteelVal) -> HeapRef<SteelVal> {
+        let pointer = Rc::new(RefCell::new(HeapAllocated::new(value)));
+        let weak_ptr = Rc::downgrade(&pointer);
+
+        self.memory.push(pointer);
+
+        HeapRef { inner: weak_ptr }
+    }
+
     // Allocate a vector explicitly onto the heap
     pub fn allocate_vector<'a>(
         &mut self,

--- a/crates/steel-language-server/src/diagnostics.rs
+++ b/crates/steel-language-server/src/diagnostics.rs
@@ -304,31 +304,96 @@ impl<'a, 'b> VisitorMutUnitRef<'a> for StaticCallSiteArityChecker<'a, 'b> {
             .and_then(|x| x.atom_syntax_object())
             .map(|x| x.syntax_object_id)
         {
-            if let Some(info) = self.context.analysis.get_identifier(function_call_ident) {
-                if info.builtin {
-                    let found_arity = self
-                        .context
-                        .engine
-                        .builtin_modules()
-                        .get_metadata_by_name(l.first_ident().unwrap().resolve())
-                        .map(|x| x.arity)
-                        .or_else(|| {
-                            // If this isn't found in the original built in modules,
-                            // attempt to find it registered globally?
-                            if let SteelVal::BoxedFunction(b) = self
-                                .context
-                                .engine
-                                .extract_value(l.first_ident().unwrap().resolve())
-                                .ok()?
-                            {
-                                b.arity.map(Arity::Exact)
-                            } else {
-                                None
-                            }
-                        });
+            // If it is something that... doesn't happen in the file we're currently
+            // looking at - we probably shouldn't report it there?
+            if !l.first_ident().unwrap().resolve().starts_with("mangler") {
+                if let Some(info) = self.context.analysis.get_identifier(function_call_ident) {
+                    if info.builtin {
+                        let found_arity = self
+                            .context
+                            .engine
+                            .builtin_modules()
+                            .get_metadata_by_name(l.first_ident().unwrap().resolve())
+                            .map(|x| x.arity)
+                            .or_else(|| {
+                                // If this isn't found in the original built in modules,
+                                // attempt to find it registered globally?
+                                if let SteelVal::BoxedFunction(b) = self
+                                    .context
+                                    .engine
+                                    .extract_value(l.first_ident().unwrap().resolve())
+                                    .ok()?
+                                {
+                                    b.arity.map(Arity::Exact)
+                                } else {
+                                    None
+                                }
+                            });
 
-                    match found_arity {
-                        Some(Arity::Exact(arity)) => {
+                        match found_arity {
+                            Some(Arity::Exact(arity)) => {
+                                if l.args.len() != arity + 1 {
+                                    let span =
+                                        l.first().unwrap().atom_syntax_object().unwrap().span;
+
+                                    if let Some(diagnostic) = create_diagnostic(
+                                        &self.context.rope,
+                                        &span,
+                                        format!(
+                                            "Arity mismatch: {} expects {} arguments, found {}",
+                                            l.first().unwrap(),
+                                            arity,
+                                            l.args.len() - 1
+                                        ),
+                                    ) {
+                                        self.diagnostics.push(diagnostic);
+                                    }
+                                }
+                            }
+                            Some(Arity::AtLeast(arity)) => {
+                                if l.args.len() <= arity + 1 {
+                                    let span =
+                                        l.first().unwrap().atom_syntax_object().unwrap().span;
+
+                                    if let Some(diagnostic) = create_diagnostic(
+                                    &self.context.rope,
+                                    &span,
+                                    format!(
+                                        "Arity mismatch: {} expects at least {} arguments, found {}",
+                                        l.first().unwrap(),
+                                        arity,
+                                        l.args.len() - 1
+                                    ),
+                                ) {
+                                    self.diagnostics.push(diagnostic);
+                                }
+                                }
+                            }
+                            Some(Arity::AtMost(arity)) => {
+                                if l.args.len() > arity + 1 {
+                                    let span =
+                                        l.first().unwrap().atom_syntax_object().unwrap().span;
+
+                                    if let Some(diagnostic) = create_diagnostic(
+                                        &self.context.rope,
+                                        &span,
+                                        format!(
+                                        "Arity mismatch: {} expects at most {} arguments, found {}",
+                                        l.first().unwrap(),
+                                        arity,
+                                        l.args.len() - 1
+                                    ),
+                                    ) {
+                                        self.diagnostics.push(diagnostic);
+                                    }
+                                }
+                            }
+                            // TODO: Handle this arity if it comes up
+                            Some(Arity::Range(n)) => {}
+                            None => {}
+                        }
+                    } else if let Some(refers_to_id) = info.refers_to {
+                        if let Some(arity) = self.known_functions.get(&refers_to_id) {
                             if l.args.len() != arity + 1 {
                                 let span = l.first().unwrap().atom_syntax_object().unwrap().span;
 
@@ -344,64 +409,6 @@ impl<'a, 'b> VisitorMutUnitRef<'a> for StaticCallSiteArityChecker<'a, 'b> {
                                 ) {
                                     self.diagnostics.push(diagnostic);
                                 }
-                            }
-                        }
-                        Some(Arity::AtLeast(arity)) => {
-                            if l.args.len() <= arity + 1 {
-                                let span = l.first().unwrap().atom_syntax_object().unwrap().span;
-
-                                if let Some(diagnostic) = create_diagnostic(
-                                    &self.context.rope,
-                                    &span,
-                                    format!(
-                                        "Arity mismatch: {} expects at least {} arguments, found {}",
-                                        l.first().unwrap(),
-                                        arity,
-                                        l.args.len() - 1
-                                    ),
-                                ) {
-                                    self.diagnostics.push(diagnostic);
-                                }
-                            }
-                        }
-                        Some(Arity::AtMost(arity)) => {
-                            if l.args.len() > arity + 1 {
-                                let span = l.first().unwrap().atom_syntax_object().unwrap().span;
-
-                                if let Some(diagnostic) = create_diagnostic(
-                                    &self.context.rope,
-                                    &span,
-                                    format!(
-                                        "Arity mismatch: {} expects at most {} arguments, found {}",
-                                        l.first().unwrap(),
-                                        arity,
-                                        l.args.len() - 1
-                                    ),
-                                ) {
-                                    self.diagnostics.push(diagnostic);
-                                }
-                            }
-                        }
-                        // TODO: Handle this arity if it comes up
-                        Some(Arity::Range(n)) => {}
-                        None => {}
-                    }
-                } else if let Some(refers_to_id) = info.refers_to {
-                    if let Some(arity) = self.known_functions.get(&refers_to_id) {
-                        if l.args.len() != arity + 1 {
-                            let span = l.first().unwrap().atom_syntax_object().unwrap().span;
-
-                            if let Some(diagnostic) = create_diagnostic(
-                                &self.context.rope,
-                                &span,
-                                format!(
-                                    "Arity mismatch: {} expects {} arguments, found {}",
-                                    l.first().unwrap(),
-                                    arity,
-                                    l.args.len() - 1
-                                ),
-                            ) {
-                                self.diagnostics.push(diagnostic);
                             }
                         }
                     }

--- a/crates/steel-language-server/src/diagnostics.rs
+++ b/crates/steel-language-server/src/diagnostics.rs
@@ -58,13 +58,20 @@ impl DiagnosticGenerator for FreeIdentifiersAndUnusedIdentifiers {
                     return None;
                 }
 
+                let resolved = ident.resolve();
+
+                // We can just ignore those as well
+                if resolved.starts_with("mangler") {
+                    return None;
+                }
+
                 let start_position = offset_to_position(span.start, &context.rope)?;
                 let end_position = offset_to_position(span.end, &context.rope)?;
 
                 // TODO: Publish the diagnostics for each file separately, if we have them
                 Some(make_error(Diagnostic::new_simple(
                     Range::new(start_position, end_position),
-                    format!("free identifier: {}", ident.resolve()),
+                    format!("free identifier: {}", resolved),
                 )))
             })
             .chain(


### PR DESCRIPTION
This PR adds support for native threads; however, the overhead for thread creation is quite hefty, and are akin to `places` in racket.

From my testing, spawning a new thread can take 1-2 ms, which if used in a thread pool of some kind could be reasonable.