### PR TITLE
Add custom lints to the language server

### DIFF
--- a/crates/steel-language-server/src/backend.rs
+++ b/crates/steel-language-server/src/backend.rs
@@ -942,17 +942,18 @@ fn configure_lints() -> std::result::Result<UserDefinedLintEngine, Box<dyn Error
 
     engine.register_module(diagnostics);
 
-    // Load all of the lints - we'll want to grab
-    // all functions that get registered via define-lint - which means
-    // just give me a name
-    for file in std::fs::read_dir(&directory)? {
-        let file = file?;
+    if let Ok(directory) = std::fs::read_dir(directory) {
+        for file in directory {
+            let file = file?;
 
-        if file.path().is_file() {
-            let contents = std::fs::read_to_string(file.path())?;
+            if file.path().is_file() {
+                let contents = std::fs::read_to_string(file.path())?;
 
-            engine.compile_and_run_raw_program(&contents)?;
+                engine.compile_and_run_raw_program(&contents)?;
+            }
         }
+    } else {
+        log::info!("Missing lints directory in $STEEL_LSP_HOME");
     }
 
     Ok(UserDefinedLintEngine { engine, lints })


### PR DESCRIPTION
By adding files in the `$STEEL_LSP_HOME/lints` directory, you can add custom lints:

```scheme
(require-builtin "lsp/diagnostics")

(define-syntax define/lint
  (syntax-rules ()
    [(_ (name expr) pat ...)

     (begin
       (define name
         (lambda (expr)

           (match-syntax expr
             pat ...
             [other other])

           (match-syntax expr
             [(list other ...)
              (syntax/loc (map name other)
                (syntax-span expr))]

             [other other])))

       (#%register-lint (symbol->string (quote name))))]))

;; define/lint
(define/lint (null-cdr-check expr)
             [`(null? (cdr ,expr))
              (suggest (syntax-span expr) "Consider turning this into cdr-null?")])

```