### PR TITLE
Use xtask for various project tasks

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+[target.aarch64-unknown-linux-gnu]
+linker = "/usr/bin/aarch64-linux-gnu-gcc"
+
+[alias]
+xtask = "run --package xtask --"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4304,6 +4304,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "xtask"
+version = "0.6.0"
+
+[[package]]
 name = "zerocopy"
 version = "0.7.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "xtask"
+edition = "2021"
+version.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -1,0 +1,71 @@
+use std::{
+    error::Error,
+    path::{Path, PathBuf},
+};
+
+fn workspace_dir() -> PathBuf {
+    let output = std::process::Command::new(env!("CARGO"))
+        .arg("locate-project")
+        .arg("--workspace")
+        .arg("--message-format=plain")
+        .output()
+        .unwrap()
+        .stdout;
+    let cargo_path = Path::new(std::str::from_utf8(&output).unwrap().trim());
+    cargo_path.parent().unwrap().to_path_buf()
+}
+
+// Generate documentation by invoking the docs script!
+fn generate_docs() -> Result<(), Box<dyn Error>> {
+    println!("Generating docs...");
+
+    let mut workspace_dir = workspace_dir();
+
+    let mut base = workspace_dir.clone();
+
+    workspace_dir.push("crates");
+    workspace_dir.push("steel-doc");
+
+    std::process::Command::new("cargo")
+        .arg("run")
+        .current_dir(&workspace_dir)
+        .spawn()?
+        .wait()?;
+
+    workspace_dir.pop();
+    workspace_dir.pop();
+
+    workspace_dir.push("docs");
+    workspace_dir.push("src");
+    workspace_dir.push("builtins");
+
+    println!("Cleaning target directory...");
+
+    std::fs::remove_dir_all(&workspace_dir)?;
+
+    base.push("crates");
+    base.push("steel-doc");
+    base.push("generated");
+
+    println!("Moving generated docs into place...");
+
+    std::fs::rename(base, &workspace_dir)?;
+
+    println!("Done!");
+
+    Ok(())
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let task = std::env::args().nth(1);
+    match task {
+        None => {}
+        Some(t) => match t.as_str() {
+            "docgen" => generate_docs()?,
+            // "themelint" => tasks::themelint(env::args().nth(2))?,
+            // "query-check" => tasks::querycheck()?,
+            invalid => return Err(format!("Invalid task name: {}", invalid).into()),
+        },
+    };
+    Ok(())
+}


### PR DESCRIPTION
Adds the following commands:

* `cargo xtask install` - installs all rust binaries (repl, language server, dylib installer)
* `cargo xtask cogs` - installs the cog libraries
* `cargo xtask docgen` - generates any docs from builtins
* `cargo xtask test` - runs all of the tests