### PR TITLE
Add additional search paths for module resolution

### DIFF
--- a/crates/steel-core/src/compiler/compiler.rs
+++ b/crates/steel-core/src/compiler/compiler.rs
@@ -296,6 +296,8 @@ pub struct Compiler {
 
     analysis: Analysis,
     shadowed_variable_renamer: RenameShadowedVariables,
+
+    search_dirs: Vec<PathBuf>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -364,6 +366,7 @@ impl Compiler {
             lifted_macro_environments: HashSet::new(),
             analysis: Analysis::pre_allocated(),
             shadowed_variable_renamer: RenameShadowedVariables::default(),
+            search_dirs: Vec::new(),
         }
     }
 
@@ -387,6 +390,7 @@ impl Compiler {
             lifted_macro_environments: HashSet::new(),
             analysis: Analysis::pre_allocated(),
             shadowed_variable_renamer: RenameShadowedVariables::default(),
+            search_dirs: Vec::new(),
         }
     }
 
@@ -424,6 +428,10 @@ impl Compiler {
 
     pub fn register_builtin(&mut self, name: String, contents: String) {
         self.module_manager.add_builtin_module(name, contents);
+    }
+
+    pub fn add_search_directory(&mut self, dir: PathBuf) {
+        self.search_dirs.push(dir);
     }
 
     pub fn compile_executable_from_expressions(
@@ -549,7 +557,7 @@ impl Compiler {
         sources: &mut Sources,
         builtin_modules: ModuleContainer,
     ) -> Result<Vec<ExprKind>> {
-        #[cfg(feature = "modules")]
+        // #[cfg(feature = "modules")]
         return self.module_manager.compile_main(
             &mut self.macro_env,
             &mut self.kernel,
@@ -559,11 +567,12 @@ impl Compiler {
             builtin_modules,
             &mut self.lifted_kernel_environments,
             &mut self.lifted_macro_environments,
+            &self.search_dirs,
         );
 
-        #[cfg(not(feature = "modules"))]
-        self.module_manager
-            .expand_expressions(&mut self.macro_env, exprs)
+        // #[cfg(not(feature = "modules"))]
+        // self.module_manager
+        //     .expand_expressions(&mut self.macro_env, exprs)
     }
 
     fn generate_instructions_for_executable(

--- a/crates/steel-core/src/steel_vm/engine.rs
+++ b/crates/steel-core/src/steel_vm/engine.rs
@@ -1191,6 +1191,15 @@ impl Engine {
         engine
     }
 
+    /// Adds a directory for the engine to resolve paths from.
+    ///
+    /// By default, the engine will search $STEEL_HOME/cogs for modules,
+    /// but any additional path added this way will increase the module
+    /// resolution search space.
+    pub fn add_search_directory(&mut self, dir: PathBuf) {
+        self.compiler.add_search_directory(dir)
+    }
+
     pub(crate) fn new_printer() -> Self {
         let mut engine = fresh_kernel_image();
 

--- a/crates/steel-language-server/src/backend.rs
+++ b/crates/steel-language-server/src/backend.rs
@@ -647,6 +647,7 @@ fn filter_interned_string_with_char(
 
     if !resolved.starts_with("#")
         && !resolved.starts_with("%")
+        && !resolved.starts_with("mangler")
         && !resolved.starts_with("mangler#%")
         && !resolved.starts_with("!!dummy-rest")
         && !resolved.starts_with("__module-mangler")

--- a/crates/steel-language-server/src/main.rs
+++ b/crates/steel-language-server/src/main.rs
@@ -54,6 +54,7 @@ async fn main() {
             if !resolved.starts_with("#")
                 && !resolved.starts_with("%")
                 && !resolved.starts_with("mangler#%")
+                && !resolved.starts_with("mangler")
             {
                 defined_globals.insert(resolved.to_string());
             }

--- a/crates/steel-webrequests/src/lib.rs
+++ b/crates/steel-webrequests/src/lib.rs
@@ -13,21 +13,30 @@ fn create_module() -> FFIModule {
 
     module
         .register_fn("get", get)
+        .register_fn("post", post)
+        .register_fn("put", put)
+        .register_fn("delete", delete)
+        .register_fn("patch", patch)
+        .register_fn("head", head)
+        .register_fn("set-header!", BlockingRequest::set)
+        .register_fn("set-query-parameter!", BlockingRequest::query)
+        .register_fn("set-timeout/ms!", BlockingRequest::timeout_ms)
         .register_fn(
             "call",
             |request: BlockingRequest| -> Result<SteelResponse, BlockingError> {
-                Request::call(request.0)
+                Request::call(request.0.unwrap())
                     .map(|x| x.into())
                     .map_err(BlockingError::Ureq)
             },
         )
+        .register_fn("call-with-json", BlockingRequest::call_with_json)
         .register_fn("response->text", SteelResponse::into_text);
 
     module
 }
 
 #[derive(Clone)]
-struct BlockingRequest(Request);
+struct BlockingRequest(Option<Request>);
 struct BlockingResponse(Response);
 
 enum BlockingError {
@@ -40,7 +49,53 @@ impl Custom for BlockingResponse {}
 impl Custom for BlockingError {}
 
 fn get(url: String) -> BlockingRequest {
-    BlockingRequest(ureq::get(&url))
+    BlockingRequest(Some(ureq::get(&url)))
+}
+
+fn post(url: String) -> BlockingRequest {
+    BlockingRequest(Some(ureq::post(&url)))
+}
+
+fn put(url: String) -> BlockingRequest {
+    BlockingRequest(Some(ureq::put(&url)))
+}
+
+fn delete(url: String) -> BlockingRequest {
+    BlockingRequest(Some(ureq::delete(&url)))
+}
+
+fn patch(url: String) -> BlockingRequest {
+    BlockingRequest(Some(ureq::patch(&url)))
+}
+
+fn head(url: String) -> BlockingRequest {
+    BlockingRequest(Some(ureq::head(&url)))
+}
+
+impl BlockingRequest {
+    fn query(&mut self, parameter: String, value: String) {
+        self.0 = Some(self.0.take().unwrap().query(&parameter, &value));
+    }
+
+    fn set(&mut self, header: String, value: String) {
+        self.0 = Some(self.0.take().unwrap().set(&header, &value));
+    }
+
+    // TODO: Add FFI conversion form u64 as well
+    fn timeout_ms(&mut self, time_in_ms: usize) {
+        self.0 = Some(
+            self.0
+                .take()
+                .unwrap()
+                .timeout(std::time::Duration::from_millis(time_in_ms as u64)),
+        );
+    }
+
+    fn call_with_json(&mut self, json: String) -> Result<SteelResponse, BlockingError> {
+        Request::send_json(self.0.clone().unwrap(), json)
+            .map(|x| x.into())
+            .map_err(BlockingError::Ureq)
+    }
 }
 
 struct SteelResponse {

--- a/crates/steel-webrequests/webrequests.scm
+++ b/crates/steel-webrequests/webrequests.scm
@@ -1,5 +1,43 @@
-(#%require-dylib "libsteel_webrequests" (only-in get call response->text))
+(#%require-dylib "libsteel_webrequests"
+                 (only-in get
+                          post
+                          put
+                          delete
+                          patch
+                          head
+                          call
+                          call-with-json
+                          response->text
+                          set-query-parameter!
+                          set-header!
+                          set-timeout/ms!))
 
 (provide get
+         post
+         put
+         delete
+         patch
+         head
+         call-with-json-body
+         set-query-parameter!
+         set-header!
+         set-timeout/ms!
          call
-         response->text)
+         response->text
+         response->json
+         with-query-parameter
+         with-header)
+
+(define (response->json resp)
+  (string->jsexpr (response->text resp)))
+
+(define (with-query-parameter req)
+  (set-query-parameter! req)
+  req)
+
+(define (with-header req)
+  (set-header! req)
+  req)
+
+(define (call-with-json-body req json)
+  (call-with-json req (value->jsexpr-string json)))


### PR DESCRIPTION
When embedding steel within a host application, you might want to store files in a specific spot, and not rely on the steel home for storing files - this allows adding a configuration when creating the engine on where to resolve modules.