### PR TITLE
core: Fix panic on division by integer 0

### DIFF
--- a/crates/steel-core/src/primitives/numbers.rs
+++ b/crates/steel-core/src/primitives/numbers.rs
@@ -214,6 +214,7 @@ pub fn divide_primitive(args: &[SteelVal]) -> Result<SteelVal> {
     let recip = |x: &SteelVal| -> Result<SteelVal> {
         match x {
             SteelVal::IntV(n) => match i32::try_from(*n) {
+                Ok(0) => Ok(SteelVal::NumV(f64::INFINITY)),
                 Ok(n) => Rational32::new(1, n).into_steelval(),
                 Err(_) => BigRational::new(BigInt::from(1), BigInt::from(*n)).into_steelval(),
             },
@@ -1084,6 +1085,14 @@ mod num_op_tests {
             divide_primitive(&[IntV(10), IntV(2)]).unwrap().to_string(),
             IntV(5).to_string()
         );
+    }
+
+    #[test]
+    fn dvision_by_integer_zero_returns_positive_infinity() {
+        assert_eq!(
+            divide_primitive(&[IntV(1), IntV(0)]).unwrap().to_string(),
+            NumV(f64::INFINITY).to_string()
+        )
     }
 
     #[test]


### PR DESCRIPTION
Division by `0isize` now behaves the same as division by `0f64`. Both produce `+inf.0`.

```scheme
(= (/ 1 0) (/ 1 0.0)) ; => #true
```