### PR TITLE
core: Support path expansion (#87)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -945,7 +945,16 @@ version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys 0.4.1",
 ]
 
 [[package]]
@@ -967,6 +976,18 @@ dependencies = [
  "libc",
  "redox_users",
  "winapi",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2100,6 +2121,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
@@ -3293,6 +3320,7 @@ dependencies = [
  "cranelift-jit",
  "cranelift-module",
  "criterion",
+ "dirs 5.0.1",
  "env_logger",
  "futures-executor",
  "futures-task",
@@ -3643,7 +3671,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da31aef70da0f6352dbcb462683eb4dd2bfad01cf3fc96cf204547b9a839a585"
 dependencies = [
- "dirs",
+ "dirs 4.0.0",
  "fnv",
  "nom",
  "phf 0.11.2",

--- a/crates/steel-core/Cargo.toml
+++ b/crates/steel-core/Cargo.toml
@@ -37,6 +37,7 @@ steel-gen = { path = "../steel-gen", version = "0.2.0" }
 steel-parser = { path = "../steel-parser", version = "0.6.0" }
 steel-derive = { path = "../steel-derive", version = "0.5.0" }
 chrono = { version = "0.4.23", default-features = false, features = ["std", "clock"] }
+dirs = "5.0.1"
 weak-table = "0.3.2"
 # TODO: Consider whether rand needs to be here
 rand = "0.8.5"

--- a/docs/src/builtins/steel_filesystem.md
+++ b/docs/src/builtins/steel_filesystem.md
@@ -13,6 +13,8 @@ Check the current working directory
 Deletes the directory
 ### **file-name**
 Gets the filename for a given path
+### **canonicalize-path**
+Returns canonical path with all components normalized
 ### **is-dir?**
 Checks if a path is a directory
 ### **is-file?**


### PR DESCRIPTION
`std::fs::canonicalize` does most of the work, but it doesn't expand `~`. `std::env::home_dir` is deprecated. So I added the `dirs` dependency, which is relatively light and only has one dependency.

Features:
- `.` and `..` are resolved
- `~` is resolved to the current users home directory (should work on all major OSs; see the documentation for `dirs::home_dir`)
- symbolic links are resolved (see `std::fs::canonicalize`)

Limitations:
- expansion of other users home directories is not supported (~user/)
- expansion only works for files which exist on the filesystem (see `std::fs::canonicalize`)

Closes #87