### PR TITLE
fix `flake.nix` - install `cargo-steel-lib` properly during `steel` build

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,11 +22,12 @@
 
       manifest = pkgs.lib.importTOML ./Cargo.toml;
       steel = with pkgs;
-        rustPlatform.buildRustPackage rec {
+        rustPlatform.buildRustPackage {
           pname = manifest.package.name;
           version = manifest.workspace.package.version;
           src = gitignoreSource ./.;
           cargoLock.lockFile = ./Cargo.lock;
+          cargoBuildFlags = "-p cargo-steel-lib -p steel-interpreter";
           buildInputs = [openssl] ++ lib.optionals stdenv.isDarwin [darwin.apple_sdk.frameworks.Security];
           nativeBuildInputs = [
             pkg-config
@@ -34,11 +35,13 @@
           # Test failing
           doCheck = false;
           postInstall = ''
+            substituteInPlace /build/source/cogs/installer/download.scm --replace-warn "cargo-steel-lib" "$out/bin/cargo-steel-lib"
             mkdir $out/lib
             export STEEL_HOME="$out/lib"
             pushd cogs
             $out/bin/steel install.scm
             popd
+            rm "$out/bin/cargo-steel-lib"
           '';
         };
     in rec {

--- a/flake.nix
+++ b/flake.nix
@@ -57,5 +57,10 @@
             rust-analyzer
           ];
         };
+      apps.steel = {
+        type = "app";
+        program = "${steel}/bin/steel";
+      };
+      apps.default = apps.steel;
     });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -42,15 +42,17 @@
           '';
         };
     in rec {
+      formatter = pkgs.alejandra;
       packages.steel = steel;
       legacyPackages = packages;
       defaultPackage = packages.steel;
-      devShell = with pkgs; mkShell {
-        buildInputs = [cargo openssl] ++ lib.optionals stdenv.isDarwin [darwin.apple_sdk.frameworks.Security];
-        nativeBuildInputs = [
-          pkg-config
-          rust-analyzer
-        ];
-      };
+      devShell = with pkgs;
+        mkShell {
+          buildInputs = [cargo openssl] ++ lib.optionals stdenv.isDarwin [darwin.apple_sdk.frameworks.Security];
+          nativeBuildInputs = [
+            pkg-config
+            rust-analyzer
+          ];
+        };
     });
 }


### PR DESCRIPTION
This closes #182.

I create a new package `cargo-steel-lib` with is then used as a native build input for the actual installation of `steel`.

Minor changes:
- I removed an unnecessary `rec` (my linter was complaining)
- I added `rust-analyzer` such that a lsp is available during rust development (slight overlap with #178)
- I added the `alejandra` formatter and formatted all nix files using `nix fmt`. Really the only purpose of this change is defining a fixed style to use for `*.nix` files in this flake.