### PR TITLE
Fix load cmd error handling in repl

### DIFF
--- a/crates/steel-repl/src/repl.rs
+++ b/crates/steel-repl/src/repl.rs
@@ -26,6 +26,7 @@ fn display_help() {
         :? | :help  -- displays help dialog
         :quit       -- exits the REPL
         :pwd        -- displays the current working directory
+        :load       -- loads a file
         "
     );
 }
@@ -159,12 +160,10 @@ pub fn repl_base(mut vm: Engine) -> std::io::Result<()> {
                     ":?" | ":help" => display_help(),
                     line if line.contains(":load") => {
                         let line = line.trim_start_matches(":load").trim();
-
-                        // Update the prompt to now include the new context
-                        prompt = format!(
-                            "{}",
-                            format!("λ ({line}) > ").bright_green().bold().italic(),
-                        );
+                        if line.is_empty() {
+                            eprintln!("No file provided");
+                            continue;
+                        }
 
                         let path = Path::new(line);
 
@@ -174,6 +173,12 @@ pub fn repl_base(mut vm: Engine) -> std::io::Result<()> {
                             eprintln!("{e}");
                             continue;
                         }
+
+                        // Update the prompt to now include the new context
+                        prompt = format!(
+                            "{}",
+                            format!("λ ({line}) > ").bright_green().bold().italic(),
+                        );
 
                         let mut file = file?;
 


### PR DESCRIPTION
Fixes https://github.com/mattwparas/steel/issues/167

Noticed some bugs in the `:load` repl command. 
* Adds error message when no file provided to `:load`
* No longer switches prompt context when file cannot be opened
* Adds `:load` command to help output

See below for example of new error handling:

```
     _____ __            __
    / ___// /____  ___  / /          Version 0.5.0
    \__ \/ __/ _ \/ _ \/ /           https://github.com/mattwparas/steel
   ___/ / /_/  __/  __/ /            :? for help
  /____/\__/\___/\___/_/
    
λ > :?

        :time       -- toggles the timing of expressions
        :? | :help  -- displays help dialog
        :quit       -- exits the REPL
        :pwd        -- displays the current working directory
        :load       -- loads a file
        
λ > :load
No file provided
λ > :load non-existent.scm
No such file or directory (os error 2)
λ > :load hello.scm
Hello World
λ (hello.scm) > 

```

Let me know if anything needs changed as I'm fairly new to Rust!