### PR TITLE
Load and save history on repl start/exit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ docs/theme
 .vscode/
 /result
 .direnv/
+.steel/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3001,6 +3001,7 @@ name = "steel-repl"
 version = "0.6.0"
 dependencies = [
  "colored",
+ "dirs",
  "rustyline",
  "rustyline-derive",
  "steel-core",

--- a/crates/steel-repl/Cargo.toml
+++ b/crates/steel-repl/Cargo.toml
@@ -15,3 +15,4 @@ rustyline-derive = "0.7.0"
 colored = "2.0.0"
 steel-core = { workspace = true }
 steel-parser = { path = "../steel-parser", version = "0.6.0"}
+dirs = "5.0.1"

--- a/crates/steel-repl/src/repl.rs
+++ b/crates/steel-repl/src/repl.rs
@@ -19,6 +19,8 @@ use std::time::Instant;
 
 use std::env;
 
+use std::fs::File;
+
 use dirs;
 
 use crate::highlight::RustylineHelper;
@@ -138,9 +140,11 @@ pub fn repl_base(mut vm: Engine) -> std::io::Result<()> {
 
     // Load repl history
     let history_path = get_repl_history_path();
-    if let Err(err) = rl.load_history(&history_path) {
-        eprintln!("Failed to load REPL history: {}", err);
-    }
+    if let Err(_) = rl.load_history(&history_path) {
+        if let Err(_) = File::create(&history_path) {
+            eprintln!("Unable to create repl history file {:?}", history_path)
+        }
+    };
 
     let current_dir = std::env::current_dir()?;
 

--- a/crates/steel-repl/src/repl.rs
+++ b/crates/steel-repl/src/repl.rs
@@ -61,7 +61,7 @@ fn get_repl_history_path() -> String {
             parsed_path = parsed_path.canonicalize().unwrap_or(parsed_path);
             parsed_path.push("history");
             parsed_path.to_string_lossy().into_owned()
-        },
+        }
         Err(_) => {
             let mut default_path = dirs::home_dir().unwrap_or_default();
             default_path.push(".steel/history");


### PR DESCRIPTION
Adds functionality to load/save REPL history, it defaults to the path `~/.steel/history` unless `STEEL_HOME` is set. 