### PR TITLE
Add divider to playground/book links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ An embeddable and extensible scheme dialect built in Rust.
 <a href="https://mattwparas.github.io/steel-playground/dev">
     <b>Try it on the Playground</b>
 </a>
-
+·
 <a href="https://mattwparas.github.io/steel/book">
     <b>Read the Steel book (WIP)</b>
 </a>


### PR DESCRIPTION
Tiny PR, just adds a small divider in between the links for clarity in the README.