### PR TITLE
fix string functions based on character offsets

### DIFF
--- a/cogs/r5rs.scm
+++ b/cogs/r5rs.scm
@@ -391,6 +391,8 @@
 (check-equal? "string indexing into last character" #\c (string-ref "abc" 2))
 
 (check-equal? "empty substring" "" (substring "abc" 0 0))
+(check-equal? "empty substring at the end" "" (substring "abc" 3 3))
+(check-equal? "empty substring in the middle" "" (substring "abc" 1 1))
 (check-equal? "substring just the first character" "a" (substring "abc" 0 1))
 (check-equal? "substring a larger chunk" "bc" (substring "abc" 1 3))
 (check-equal? "substring with multibyte characters" "λμ" (substring "λλμν" 1 3))

--- a/cogs/r5rs.scm
+++ b/cogs/r5rs.scm
@@ -387,15 +387,16 @@
 
 (check-equal? "string indexing into first character" #\a (string-ref "abc" 0))
 (check-equal? "string indexing with multibyte characters" #\a (string-ref "λa" 1))
-
 (check-equal? "string indexing into last character" #\c (string-ref "abc" 2))
 
 (check-equal? "empty substring" "" (substring "abc" 0 0))
 (check-equal? "empty substring at the end" "" (substring "abc" 3 3))
+(check-equal? "substring without end" "bc" (substring "abc" 1))
 (check-equal? "empty substring in the middle" "" (substring "abc" 1 1))
 (check-equal? "substring just the first character" "a" (substring "abc" 0 1))
 (check-equal? "substring a larger chunk" "bc" (substring "abc" 1 3))
 (check-equal? "substring with multibyte characters" "λμ" (substring "λλμν" 1 3))
+(check-equal? "full substring with multibyte characters" "千葉市" (substring "千葉市" 0 3))
 
 (check-equal? "Basic functionality of make-string" "aaa" (make-string 3 #\a))
 (check-equal? "make-string with no character" "\0\0\0" (make-string 3))

--- a/cogs/r5rs.scm
+++ b/cogs/r5rs.scm
@@ -386,12 +386,14 @@
 (check-equal? "string length correctly reported for standard string" 3 (string-length "abc"))
 
 (check-equal? "string indexing into first character" #\a (string-ref "abc" 0))
+(check-equal? "string indexing with multibyte characters" #\a (string-ref "λa" 1))
 
 (check-equal? "string indexing into last character" #\c (string-ref "abc" 2))
 
 (check-equal? "empty substring" "" (substring "abc" 0 0))
 (check-equal? "substring just the first character" "a" (substring "abc" 0 1))
 (check-equal? "substring a larger chunk" "bc" (substring "abc" 1 3))
+(check-equal? "substring with multibyte characters" "λμ" (substring "λλμν" 1 3))
 
 (check-equal? "Basic functionality of make-string" "aaa" (make-string 3 #\a))
 (check-equal? "make-string with no character" "\0\0\0" (make-string 3))


### PR DESCRIPTION
I noticed a couple of potential issues with string functions and multi-byte characters. I'm assuming that the affected functions are supposed to be character-based, and not byte based (unlike `string-length`).