### PR TITLE
wrap env::set_var in a closure

### DIFF
--- a/crates/steel-core/src/steel_vm/primitives.rs
+++ b/crates/steel-core/src/steel_vm/primitives.rs
@@ -1454,7 +1454,7 @@ fn meta_module() -> BuiltInModule {
         .register_value("%iterator?", gen_pred!(BoxedIterator))
         .register_fn("env-var", get_environment_variable)
         .register_fn("maybe-get-env-var", maybe_get_environment_variable)
-        .register_fn("set-env-var!", std::env::set_var::<String, String>)
+        .register_fn("set-env-var!", |name, val| std::env::set_var::<String, String>(name, val))
         .register_fn("arity?", arity)
         .register_fn("function-name", lookup_function_name)
         .register_fn("#%native-fn-ptr-doc", lookup_doc)


### PR DESCRIPTION
This is in preparation for https://github.com/rust-lang/rust/pull/124636, where we're making `set_var` unsafe. On old (pre-2024) editions, the unsafety error is downgraded to a warning so old code largely keeps working -- except when `set_var` is coerced to a function pointer, as is done by this crate (and by no other crate it seems); then the true type of `set_var` being an `unsafe fn` shines through and the build [fails](https://crater-reports.s3.amazonaws.com/pr-124636/try%23f7e82692c94525c7ff9c5e366c953cc2ea3ca6fc/gh/mattwparas.rucket/log.txt).

So to keep this crate building with future versions of rustc, wrap `set_var` in a closure such that the closure gets coerced to a function pointer, and `set_var` just gets called the normal way.