### PR TITLE
minor repl improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -464,6 +464,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
 name = "chrono"
 version = "0.4.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -899,6 +905,16 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "ctrlc"
+version = "3.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "672465ae37dc1bc6380a6547a8883d5dd397b0f1faaad4f265726cc7042a5345"
+dependencies = [
+ "nix 0.28.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1808,6 +1824,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.4.2",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "num"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2558,7 +2586,7 @@ dependencies = [
  "libc",
  "log",
  "memchr",
- "nix",
+ "nix 0.25.1",
  "radix_trie",
  "scopeguard",
  "unicode-segmentation",
@@ -3001,6 +3029,7 @@ name = "steel-repl"
 version = "0.6.0"
 dependencies = [
  "colored",
+ "ctrlc",
  "dirs",
  "rustyline",
  "rustyline-derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,9 @@ path = "src/main.rs"
 # This has to line up with the workspace version above
 steel-core = { path = "./crates/steel-core", version = "0.6.0", features = ["dylibs", "markdown", "stacker", "dylib-build"] }
 
+[features]
+interrupt = ["steel-core/interrupt"]
+
 [dependencies]
 once_cell = "1.17.0"
 steel-core = { workspace = true }

--- a/crates/steel-core/Cargo.toml
+++ b/crates/steel-core/Cargo.toml
@@ -83,7 +83,7 @@ steel-gen = { path = "../steel-gen", version = "0.2.0" }
 
 [features]
 # TODO: Deprecate the modules feature flag, it no longer does anything
-default = ["modules", "interrupt"]
+default = ["modules"]
 modules = []
 jit = ["dep:cranelift", "dep:cranelift-module", "dep:cranelift-jit"]
 dynamic = []

--- a/crates/steel-core/Cargo.toml
+++ b/crates/steel-core/Cargo.toml
@@ -83,7 +83,7 @@ steel-gen = { path = "../steel-gen", version = "0.2.0" }
 
 [features]
 # TODO: Deprecate the modules feature flag, it no longer does anything
-default = ["modules"]
+default = ["modules", "interrupt"]
 modules = []
 jit = ["dep:cranelift", "dep:cranelift-module", "dep:cranelift-jit"]
 dynamic = []
@@ -96,6 +96,7 @@ smallvec = []
 without-drop-protection = []
 stacker = ["dep:stacker"]
 dylib-build = ["dep:cargo-steel-lib"]
+interrupt = []
 
 
 [[bench]]

--- a/crates/steel-core/src/steel_vm/engine.rs
+++ b/crates/steel-core/src/steel_vm/engine.rs
@@ -51,7 +51,7 @@ use std::{
     collections::{HashMap, HashSet},
     path::PathBuf,
     rc::Rc,
-    sync::Arc,
+    sync::{atomic::AtomicBool, Arc},
 };
 
 use fxhash::{FxBuildHasher, FxHashMap};
@@ -1198,6 +1198,10 @@ impl Engine {
     /// resolution search space.
     pub fn add_search_directory(&mut self, dir: PathBuf) {
         self.compiler.add_search_directory(dir)
+    }
+
+    pub fn with_interrupted(&mut self, interrupted: Arc<AtomicBool>) {
+        self.virtual_machine.with_interrupted(interrupted);
     }
 
     pub(crate) fn new_printer() -> Self {

--- a/crates/steel-core/src/steel_vm/vm.rs
+++ b/crates/steel-core/src/steel_vm/vm.rs
@@ -37,6 +37,8 @@ use crate::{
     values::functions::ByteCodeLambda,
 };
 use std::rc::Weak;
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
 use std::{cell::RefCell, collections::HashMap, iter::Iterator, rc::Rc};
 
 use super::builtin::DocTemplate;
@@ -283,6 +285,7 @@ pub struct SteelThread {
     pub(crate) current_frame: StackFrame,
     pub(crate) stack_frames: Vec<StackFrame>,
     pub(crate) constant_map: ConstantMap,
+    pub(crate) interrupted: Arc<AtomicBool>,
 }
 
 #[derive(Clone)]
@@ -347,7 +350,13 @@ impl SteelThread {
             // we'll have each thread default to an empty constant map, and replace it with the map bundled
             // with the executables
             constant_map: DEFAULT_CONSTANT_MAP.with(|x| x.clone()),
+            interrupted: Default::default(),
         }
+    }
+
+    pub fn with_interrupted(&mut self, interrupted: Arc<AtomicBool>) -> &mut Self {
+        self.interrupted = interrupted;
+        self
     }
 
     // If you want to explicitly turn off contracts, you can do so
@@ -1607,6 +1616,14 @@ impl<'a> VmCore<'a> {
 
         // while self.ip < self.instructions.len() {
         loop {
+            if self
+                .thread
+                .interrupted
+                .load(std::sync::atomic::Ordering::Relaxed)
+            {
+                stop!(Generic => "Interrupted by user"; self.current_span());
+            }
+
             // Process the op code
             // TODO: Just build up a slice, don't directly store the full vec of op codes
 

--- a/crates/steel-core/src/steel_vm/vm/threads.rs
+++ b/crates/steel-core/src/steel_vm/vm/threads.rs
@@ -380,6 +380,7 @@ fn spawn_thread_result(ctx: &mut VmCore, args: &[SteelVal]) -> Result<SteelVal> 
             current_frame: StackFrame::main(),
             stack_frames: Vec::with_capacity(32),
             constant_map,
+            interrupted: Default::default(),
         };
 
         #[cfg(feature = "profiling")]

--- a/crates/steel-repl/Cargo.toml
+++ b/crates/steel-repl/Cargo.toml
@@ -16,3 +16,4 @@ colored = "2.0.0"
 steel-core = { workspace = true }
 steel-parser = { path = "../steel-parser", version = "0.6.0"}
 dirs = "5.0.1"
+ctrlc = "3.4.4"


### PR DESCRIPTION
* `Ctrl+C` does not exit the REPL.
* `$1` is bound to the last evaluated expression.