### PR TITLE
improve list locations

### DIFF
--- a/crates/steel-core/src/rerrs.rs
+++ b/crates/steel-core/src/rerrs.rs
@@ -396,6 +396,12 @@ macro_rules! stop {
     ($type:ident => $thing:expr; $span:expr) => {
         return Err($crate::rerrs::SteelErr::new($crate::rerrs::ErrorKind::$type, ($thing).to_string()).with_span($span))
     };
+    ($type:ident => $thing:expr; opt $span:expr) => {
+        match $span {
+            Some(span) => stop!($type => $thing; span),
+            None => stop!($type => $thing)
+        }
+    };
     ($type:ident => $thing:expr; $span:expr; $source:expr) => {
         return Err($crate::rerrs::SteelErr::new($crate::rerrs::ErrorKind::$type, ($thing).to_string()).with_span($span))
 

--- a/crates/steel-core/src/steel_vm/const_evaluation.rs
+++ b/crates/steel-core/src/steel_vm/const_evaluation.rs
@@ -621,7 +621,7 @@ impl<'a> ConsumingVisitor for ConstantEvaluator<'a> {
                 if let ExprKind::LambdaFunction(f) = &func {
                     if !f.rest {
                         if !f.args.is_empty() {
-                            stop!(ArityMismatch => format!("function expected {} arguments, found 0", f.args.len()))
+                            stop!(ArityMismatch => format!("function expected {} arguments, found 0", f.args.len()); f.location.span)
                         }
 
                         // If the body is constant we can safely remove the application
@@ -894,8 +894,8 @@ impl<'a> ConsumingVisitor for ConstantEvaluator<'a> {
         Ok(ExprKind::Set(s))
     }
 
-    fn visit_require(&mut self, _s: crate::parser::ast::Require) -> Self::Output {
-        stop!(Generic => "unexpected require - require is only allowed at the top level");
+    fn visit_require(&mut self, s: crate::parser::ast::Require) -> Self::Output {
+        stop!(Generic => "unexpected require - require is only allowed at the top level"; s.location.span);
     }
 
     // TODO come back to this

--- a/crates/steel-core/src/steel_vm/engine.rs
+++ b/crates/steel-core/src/steel_vm/engine.rs
@@ -1606,10 +1606,14 @@ impl Engine {
 
     /// Emit the unexpanded AST
     pub fn emit_ast_to_string(expr: &str) -> Result<String> {
+        let parsed = Self::emit_ast(expr)?;
+        Ok(parsed.into_iter().map(|x| x.to_pretty(60)).join("\n\n"))
+    }
+
+    pub fn emit_ast(expr: &str) -> Result<Vec<ExprKind>> {
         let parsed: std::result::Result<Vec<ExprKind>, ParseError> =
             Parser::new(expr, None).collect();
-        let parsed = parsed?;
-        Ok(parsed.into_iter().map(|x| x.to_pretty(60)).join("\n\n"))
+        Ok(parsed?)
     }
 
     /// Emit the fully expanded AST as a pretty printed string

--- a/crates/steel-parser/src/ast.rs
+++ b/crates/steel-parser/src/ast.rs
@@ -155,6 +155,24 @@ macro_rules! expr_list {
 }
 
 impl ExprKind {
+    pub fn span(&self) -> Option<Span> {
+        match self {
+            ExprKind::Atom(expr) => Some(expr.syn.span),
+            ExprKind::If(expr) => Some(expr.location.span),
+            ExprKind::Let(expr) => Some(expr.location.span),
+            ExprKind::Define(expr) => Some(expr.location.span),
+            ExprKind::LambdaFunction(expr) => Some(expr.location.span),
+            ExprKind::Begin(expr) => Some(expr.location.span),
+            ExprKind::Return(expr) => Some(expr.location.span),
+            ExprKind::Quote(expr) => Some(expr.location.span),
+            ExprKind::Macro(expr) => Some(expr.location.span),
+            ExprKind::SyntaxRules(expr) => Some(expr.location.span),
+            ExprKind::List(expr) => expr.location,
+            ExprKind::Set(expr) => Some(expr.location.span),
+            ExprKind::Require(expr) => Some(expr.location.span),
+        }
+    }
+
     pub fn to_string_literal(&self) -> Option<&String> {
         if let ExprKind::Atom(a) = self {
             if let TokenType::StringLiteral(s) = &a.syn.ty {
@@ -972,9 +990,13 @@ impl List {
         }
     }
 
-    pub fn with_span(mut self, location: Span) -> Self {
-        self.location = Some(location);
-        self
+    pub fn with_spans(args: Vec<ExprKind>, open: Span, close: Span) -> Self {
+        List {
+            args,
+            improper: false,
+            location: Some(Span::merge(open, close)),
+            syntax_object_id: SyntaxObjectId::fresh().0,
+        }
     }
 
     pub fn make_improper(mut self) -> Self {


### PR DESCRIPTION
I noticed we sometimes lack span info for `ExprKind::List` instances, while I was trying to improve error locations. So this PR does both things.