### PR TITLE
fix recyclable drop

### DIFF
--- a/crates/steel-core/src/values/recycler.rs
+++ b/crates/steel-core/src/values/recycler.rs
@@ -72,7 +72,7 @@ macro_rules! impl_recyclable {
 
         impl Recyclable for $t {
             fn put(mut self) {
-                $tl.with(|p| {
+                let _ = $tl.try_with(|p| {
                     let p = p.try_borrow_mut();
 
                     if let Ok(mut p) = p {
@@ -83,7 +83,7 @@ macro_rules! impl_recyclable {
                             p.push(self);
                         }
                     }
-                })
+                });
             }
 
             fn get() -> Self {


### PR DESCRIPTION
Fixes a panic I noticed while trying the helix integration. My guess is that:
1. Static storage transitively contains recyclable values.
2. The storage gets dropped at thread exit.
3. Some recyclable value `Drop` impl is called and attempts to access the thread local.
4. And that panics b/c the thread local `Drop` call is ongoing.
