### PR TITLE
Add minimal support for improper lists in macro expansion

### DIFF
--- a/crates/steel-core/src/parser/expand_visitor.rs
+++ b/crates/steel-core/src/parser/expand_visitor.rs
@@ -190,6 +190,10 @@ impl<'a> VisitorMutRef for Expander<'a> {
                         if let ExprKind::LambdaFunction(mut lambda) =
                             parse_lambda(ident.clone(), std::mem::take(&mut l.args))?
                         {
+                            if l.improper {
+                                lambda.rest = true;
+                            }
+
                             self.visit_lambda_function(&mut lambda)?;
 
                             *expr = ExprKind::LambdaFunction(lambda);

--- a/crates/steel-core/src/tests/success/docs.scm
+++ b/crates/steel-core/src/tests/success/docs.scm
@@ -4,3 +4,10 @@
   (list 10 20 30 40 x))
 
 (assert! (equal? "This is a function that does something\n" foo__doc__))
+
+;;@doc
+;; This is a function that takes multiple arguments
+(define (bar . args)
+  (list 10 20 30 40 args))
+
+(assert! (equal? (list 10 20 30 40 (list 50 60)) (bar 50 60)))

--- a/crates/steel-parser/src/ast.rs
+++ b/crates/steel-parser/src/ast.rs
@@ -992,6 +992,15 @@ impl List {
         }
     }
 
+    pub fn new_maybe_improper(args: Vec<ExprKind>, improper: bool) -> Self {
+        List {
+            args,
+            syntax_object_id: SyntaxObjectId::fresh().0,
+            improper,
+            location: None,
+        }
+    }
+
     pub fn with_spans(args: Vec<ExprKind>, open: Span, close: Span) -> Self {
         List {
             args,
@@ -1004,6 +1013,10 @@ impl List {
     pub fn make_improper(mut self) -> Self {
         self.improper = true;
         self
+    }
+
+    pub fn set_improper(&mut self) {
+        self.improper = true;
     }
 
     pub fn is_empty(&self) -> bool {


### PR DESCRIPTION
This only partially adds support for improper lists in macro expansion, but it does preserve the fact that improper lists plumbed through ellipses patterns will stay improper post expansion.