### PR TITLE
Modern metadata for Nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -55,6 +55,12 @@
             popd
             rm "$out/bin/cargo-steel-lib"
           '';
+          meta = with lib; {
+            description = "An embedded scheme interpreter in Rust";
+            homepage = "https://github.com/mattwparas/steel";
+            license = with licenses; [asl20 mit];
+            mainProgram = "steel";
+          };
         };
     in rec {
       formatter = pkgs.alejandra;


### PR DESCRIPTION
Currently, in order to detect a binary or entry point to a program in Nix, you can use lib.getExe which requires the meta.mainProgram variable to be set. If not, you can fallback to lib.getExe'. Using this function allows you to set the mainProgram yourself which I'm not a fan of as it could result in it being changed over time. Also added other metadata that packages usually have to be complete :)