### PR TITLE
[WIP] Root the instructions to avoid refcount clones

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/main.rs"
 
 [workspace.dependencies]
 # This has to line up with the workspace version above
-steel-core = { path = "./crates/steel-core", version = "0.6.0", features = ["dylibs", "markdown", "stacker", "dylib-build"] }
+steel-core = { path = "./crates/steel-core", version = "0.6.0", features = ["dylibs", "markdown", "stacker", "dylib-build", "rooted-instructions"] }
 
 [features]
 interrupt = ["steel-core/interrupt"]

--- a/crates/steel-core/Cargo.toml
+++ b/crates/steel-core/Cargo.toml
@@ -99,6 +99,7 @@ without-drop-protection = []
 stacker = ["dep:stacker"]
 dylib-build = ["dep:cargo-steel-lib"]
 interrupt = []
+rooted-instructions = []
 
 
 [[bench]]

--- a/crates/steel-core/src/compiler/compiler.rs
+++ b/crates/steel-core/src/compiler/compiler.rs
@@ -994,9 +994,6 @@ impl Compiler {
         // Make sure to apply the peephole optimizations
         raw_program.apply_optimizations();
 
-        // Lets see everything that gets run!
-        // raw_program.debug_print();
-
         Ok(raw_program)
     }
 

--- a/crates/steel-core/src/values/closed.rs
+++ b/crates/steel-core/src/values/closed.rs
@@ -254,8 +254,10 @@ impl<'a> BreadthFirstSearchSteelValVisitor for GlobalSlotRecycler {
                         self.push_back(value.clone());
                     }
 
-                    if let Some(handler) = &frame.handler {
-                        self.push_back((*handler.as_ref()).clone());
+                    if let Some(handler) =
+                        frame.attachments.as_ref().and_then(|x| x.handler.clone())
+                    {
+                        self.push_back(handler);
                     }
                 }
             }
@@ -1052,8 +1054,10 @@ impl<'a> BreadthFirstSearchSteelValVisitor for MarkAndSweepContext<'a> {
                         self.push_back(value.clone());
                     }
 
-                    if let Some(handler) = &frame.handler {
-                        self.push_back((*handler.as_ref()).clone());
+                    if let Some(handler) =
+                        frame.attachments.as_ref().and_then(|x| x.handler.clone())
+                    {
+                        self.push_back(handler);
                     }
                 }
             }


### PR DESCRIPTION
The movement of instructions around in the VM incurs some refcount clones, swapping this out alongside some other optimizations seems to yield about an 8% speed up.

There is some unsafety which needs some more auditing, and as of now is optional.