### PR TITLE
update steel/ord

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,6 +280,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bigdecimal"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d712318a27c7150326677b321a5fa91b55f6d9034ffd67f20319e147d40cee"
+dependencies = [
+ "autocfg",
+ "libm",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2859,6 +2872,7 @@ dependencies = [
  "abi_stable",
  "anyhow",
  "async-ffi",
+ "bigdecimal",
  "bincode",
  "cargo-steel-lib",
  "chrono",

--- a/cogs/sorting/trie-sort.scm
+++ b/cogs/sorting/trie-sort.scm
@@ -29,8 +29,8 @@
     ;; children are empty, return list of empty children
     [(empty? lst) (list (trie char empty #t next-prefix))]
     ;; less than, put it to the left
-    [(< char (trie-char (first lst))) (cons (trie char empty #t next-prefix) lst)]
-    [(equal? char (trie-char (first lst))) ;; equal, step down a level
+    [(char<? char (trie-char (first lst))) (cons (trie char empty #t next-prefix) lst)]
+    [(char=? char (trie-char (first lst))) ;; equal, step down a level
      (cons (trie char (trie-children (first lst)) #t next-prefix) (rest lst))]
     ;; move to the right
     [else (cons (first lst) (create-children char-list (rest lst) prefix-chars))]))
@@ -43,9 +43,9 @@
   (cond
     [(empty? lst) ;; no children, pop off front and step down
      (list (trie char (create-children (rest char-list) empty next-prefix) #f next-prefix))]
-    [(< char (trie-char (first lst))) ;; place where it is, pop off front and go
+    [(char<? char (trie-char (first lst))) ;; place where it is, pop off front and go
      (cons (trie char (create-children (rest char-list) empty next-prefix) #f next-prefix) lst)]
-    [(equal? char (trie-char (first lst))) ;; equal, step down
+    [(char=? char (trie-char (first lst))) ;; equal, step down
      (cons (trie char
                  (create-children (rest char-list) (trie-children (first lst)) next-prefix)
                  (trie-end-word? (first lst))
@@ -64,7 +64,7 @@
 
 ;; contract: trie? trie? -> boolean?
 (define (trie<? trie-node1 trie-node2)
-  (< (trie-char trie-node1) (trie-char trie-node2)))
+  (char<? (trie-char trie-node1) (trie-char trie-node2)))
 
 ;; contract: trie? (listof string?) -> trie?
 (define (build-trie-from-list-of-words trie list-of-words)

--- a/crates/steel-core/Cargo.toml
+++ b/crates/steel-core/Cargo.toml
@@ -68,6 +68,8 @@ anyhow = { version = "1", optional = true }
 
 stacker = { version = "0.1.15", optional = true }
 
+bigdecimal = "0.4.5"
+
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "*", features = ["js"] }
 

--- a/crates/steel-core/src/rvals.rs
+++ b/crates/steel-core/src/rvals.rs
@@ -61,6 +61,7 @@ macro_rules! list {
     }};
 }
 
+use bigdecimal::BigDecimal;
 use SteelVal::*;
 
 use im_rc::{HashMap, Vector};
@@ -70,7 +71,9 @@ use futures_util::future::Shared;
 use futures_util::FutureExt;
 
 use crate::values::lists::List;
-use num::{BigInt, BigRational, Rational32, Signed, ToPrimitive, Zero};
+use num::{
+    bigint::ToBigInt, BigInt, BigRational, FromPrimitive, Rational32, Signed, ToPrimitive, Zero,
+};
 use steel_parser::tokens::{IntLiteral, RealLiteral};
 
 use self::cycles::{CycleDetector, IterativeDropHandler};
@@ -2079,33 +2082,156 @@ impl PartialOrd for SteelVal {
         // TODO: Attempt to avoid converting to f64 for cases below as it may lead to precision loss
         // at tiny and large values.
         match (self, other) {
-            (IntV(l), IntV(r)) => l.partial_cmp(r),
-            (IntV(l), NumV(r)) => partial_cmp_f64(l, r),
-            (IntV(l), Rational(r)) => partial_cmp_f64(l, r),
-            (IntV(l), BigRational(r)) => partial_cmp_f64(l, r.as_ref()),
-            (IntV(l), BigNum(r)) => BigInt::from(*l).partial_cmp(r),
-            (NumV(l), IntV(r)) => partial_cmp_f64(l, r),
-            (NumV(l), NumV(r)) => l.partial_cmp(r),
-            (NumV(l), Rational(r)) => partial_cmp_f64(l, r),
-            (NumV(l), BigRational(r)) => partial_cmp_f64(l, r.as_ref()),
-            (NumV(l), BigNum(r)) => partial_cmp_f64(l, r.as_ref()),
-            (Rational(l), Rational(r)) => l.partial_cmp(&r),
-            (Rational(l), IntV(r)) => partial_cmp_f64(l, r),
-            (Rational(l), NumV(r)) => l.to_f64()?.partial_cmp(&r),
-            (Rational(l), BigRational(r)) => partial_cmp_f64(l, r.as_ref()),
-            (Rational(l), BigNum(r)) => l.to_f64()?.partial_cmp(&r.to_f64()?),
-            (BigNum(l), IntV(r)) => l.as_ref().partial_cmp(&BigInt::from(*r)),
-            (BigNum(l), NumV(r)) => l.to_f64()?.partial_cmp(r),
-            (BigNum(l), BigNum(r)) => l.as_ref().partial_cmp(r.as_ref()),
-            (BigNum(l), Rational(r)) => partial_cmp_f64(l.as_ref(), r),
-            (BigNum(l), BigRational(r)) => partial_cmp_f64(l.as_ref(), r.as_ref()),
-            (BigRational(l), BigRational(r)) => l.as_ref().partial_cmp(r.as_ref()),
-            (BigRational(l), IntV(r)) => partial_cmp_f64(l.as_ref(), r),
-            (BigRational(l), NumV(r)) => partial_cmp_f64(l.as_ref(), r),
-            (BigRational(l), Rational(r)) => partial_cmp_f64(l.as_ref(), r),
-            (BigRational(l), BigNum(r)) => partial_cmp_f64(l.as_ref(), r.as_ref()),
+            // Comparison of matching `SteelVal` variants:
+            (IntV(x), IntV(y)) => x.partial_cmp(y),
+            (BigNum(x), BigNum(y)) => x.partial_cmp(y),
+            (Rational(x), Rational(y)) => x.partial_cmp(y),
+            (BigRational(x), BigRational(y)) => x.partial_cmp(y),
+            (NumV(x), NumV(y)) => x.partial_cmp(y),
             (StringV(s), StringV(o)) => s.partial_cmp(o),
             (CharV(l), CharV(r)) => l.partial_cmp(r),
+
+            // Comparison of `IntV`, means promoting to the rhs type
+            (IntV(x), BigNum(y)) => x
+                .to_bigint()
+                .expect("integers are representable by bigint")
+                .partial_cmp(y),
+            (IntV(x), Rational(y)) => {
+                // Since we have platform-dependent type for rational conditional compilation is required to find
+                // the common ground
+                #[cfg(target_pointer_width = "32")]
+                {
+                    let x_rational = num::Rational32::new_raw(*x as i32, 1);
+                    x_rational.partial_cmp(y)
+                }
+                #[cfg(target_pointer_width = "64")]
+                {
+                    let x_rational = num::Rational64::new_raw(*x as i64, 1);
+                    x_rational.partial_cmp(&num::Rational64::new_raw(
+                        *y.numer() as i64,
+                        *y.denom() as i64,
+                    ))
+                }
+            }
+            (IntV(x), BigRational(y)) => {
+                let x_rational = BigRational::from_integer(
+                    x.to_bigint().expect("integers are representable by bigint"),
+                );
+                x_rational.partial_cmp(y)
+            }
+            (IntV(x), NumV(y)) => (*x as f64).partial_cmp(y),
+
+            // BigNum comparisons means promoting to BigInt for integers, BigRational for ratios,
+            // or Decimal otherwise
+            (BigNum(x), IntV(y)) => x
+                .as_ref()
+                .partial_cmp(&y.to_bigint().expect("integers are representable by bigint")),
+            (BigNum(x), Rational(y)) => {
+                let x_big_rational = BigRational::from_integer(x.unwrap());
+                let y_big_rational = BigRational::new_raw(
+                    y.numer()
+                        .to_bigint()
+                        .expect("integers are representable by bigint"),
+                    y.denom()
+                        .to_bigint()
+                        .expect("integers are representable by bigint"),
+                );
+                x_big_rational.partial_cmp(&y_big_rational)
+            }
+            (BigNum(x), BigRational(y)) => {
+                let x_big_rational = BigRational::from_integer(x.unwrap());
+                x_big_rational.partial_cmp(&y)
+            }
+            (BigNum(x), NumV(y)) => {
+                let x_decimal = BigDecimal::new(x.unwrap(), 0);
+                let y_decimal_opt = BigDecimal::from_f64(*y);
+                y_decimal_opt.and_then(|y_decimal| x_decimal.partial_cmp(&y_decimal))
+            }
+
+            // Rationals require rationals, regular or bigger versions; for float it will be divided to float as well
+            (Rational(x), IntV(y)) => {
+                // Same as before, but opposite direction
+                #[cfg(target_pointer_width = "32")]
+                {
+                    let y_rational = num::Rational32::new_raw(*y as i32, 1);
+                    x.partial_cmp(&y_rational)
+                }
+                #[cfg(target_pointer_width = "64")]
+                {
+                    let y_rational = num::Rational64::new_raw(*y as i64, 1);
+                    num::Rational64::new_raw(*x.numer() as i64, *x.denom() as i64)
+                        .partial_cmp(&y_rational)
+                }
+            }
+            (Rational(x), BigNum(y)) => {
+                let x_big_rational = BigRational::new_raw(
+                    x.numer()
+                        .to_bigint()
+                        .expect("integers are representable by bigint"),
+                    x.denom()
+                        .to_bigint()
+                        .expect("integers are representable by bigint"),
+                );
+                let y_big_rational = BigRational::from_integer(y.unwrap());
+                x_big_rational.partial_cmp(&y_big_rational)
+            }
+            (Rational(x), BigRational(y)) => {
+                let x_big_rational = BigRational::new_raw(
+                    x.numer()
+                        .to_bigint()
+                        .expect("integers are representable by bigint"),
+                    x.denom()
+                        .to_bigint()
+                        .expect("integers are representable by bigint"),
+                );
+                x_big_rational.partial_cmp(&y)
+            }
+            (Rational(x), NumV(y)) => (*x.numer() as f64 / *x.denom() as f64).partial_cmp(y),
+
+            // The most capacious set, but need to cover float case with BigDecimal anyways
+            (BigRational(x), IntV(y)) => {
+                let y_rational = BigRational::from_integer(
+                    y.to_bigint().expect("integers are representable by bigint"),
+                );
+                x.as_ref().partial_cmp(&y_rational)
+            }
+            (BigRational(x), BigNum(y)) => {
+                let y_big_rational = BigRational::from_integer(y.unwrap());
+                x.as_ref().partial_cmp(&y_big_rational)
+            }
+            (BigRational(x), Rational(y)) => {
+                let y_big_rational = BigRational::new_raw(
+                    y.numer()
+                        .to_bigint()
+                        .expect("integers are representable by bigint"),
+                    y.denom()
+                        .to_bigint()
+                        .expect("integers are representable by bigint"),
+                );
+                x.as_ref().partial_cmp(&y_big_rational)
+            }
+            (BigRational(x), NumV(y)) => {
+                let x_decimal =
+                    BigDecimal::new(x.numer().clone(), 0) / BigDecimal::new(x.denom().clone(), 0);
+                let y_decimal_opt = BigDecimal::from_f64(*y);
+                y_decimal_opt.and_then(|y_decimal| x_decimal.partial_cmp(&y_decimal))
+            }
+
+            // The opposite of all float cases above
+            (NumV(x), IntV(y)) => x.partial_cmp(&(*y as f64)),
+            (NumV(x), BigNum(y)) => {
+                let x_decimal_opt = BigDecimal::from_f64(*x);
+                let y_decimal = BigDecimal::new(y.unwrap(), 0);
+                x_decimal_opt.and_then(|x_decimal| x_decimal.partial_cmp(&y_decimal))
+            }
+            (NumV(x), Rational(y)) => x.partial_cmp(&(*y.numer() as f64 / *y.denom() as f64)),
+            (NumV(x), BigRational(y)) => {
+                let x_decimal_opt = BigDecimal::from_f64(*x);
+                let y_decimal =
+                    BigDecimal::new(y.numer().clone(), 0) / BigDecimal::new(y.denom().clone(), 0);
+                x_decimal_opt.and_then(|x_decimal| x_decimal.partial_cmp(&y_decimal))
+            }
+
             (l, r) => {
                 // All real numbers (not complex) should have order defined.
                 debug_assert!(

--- a/crates/steel-core/src/scheme/trie.rkt
+++ b/crates/steel-core/src/scheme/trie.rkt
@@ -25,9 +25,9 @@
   (define next-prefix (push-back prefix-chars char))
   (cond [(empty? lst) ;; children are empty, return list of empty children
          (list (trie char empty #t next-prefix))]
-        [(< char (trie-char (first lst))) ;; less than, put it to the left
+        [(char<? char (trie-char (first lst))) ;; less than, put it to the left
          (cons (trie char empty #t next-prefix) lst)]
-        [(= char (trie-char (first lst))) ;; equal, step down a level
+        [(char=? char (trie-char (first lst))) ;; equal, step down a level
          (cons (trie char (trie-children (first lst)) #t next-prefix) (rest lst))]
         [else ;; move to the right
          (cons (first lst)
@@ -41,10 +41,10 @@
   (cond [(empty? lst) ;; no children, pop off front and step down
          (list (trie char (create-children
                            (rest char-list) empty next-prefix) #f next-prefix))]
-        [(< char (trie-char (first lst))) ;; place where it is, pop off front and go
+        [(char<? char (trie-char (first lst))) ;; place where it is, pop off front and go
          (cons (trie char (create-children
                            (rest char-list) empty next-prefix) #f next-prefix) lst)]
-        [(= char (trie-char (first lst))) ;; equal, step down
+        [(char=? char (trie-char (first lst))) ;; equal, step down
          (cons (trie char (create-children (rest char-list) (trie-children (first lst)) next-prefix)
                      (trie-end-word? (first lst))
                      (trie-word-up-to (first lst)))
@@ -64,7 +64,7 @@
 
 ; contract: trie? trie? -> boolean?
 (define (trie<? trie-node1 trie-node2)
-  (< (trie-char trie-node1) (trie-char trie-node2)))
+  (char<? (trie-char trie-node1) (trie-char trie-node2)))
 
 
 ;; contract: trie? (listof string?) -> trie?

--- a/crates/steel-core/src/steel_vm/primitives.rs
+++ b/crates/steel-core/src/steel_vm/primitives.rs
@@ -981,7 +981,7 @@ fn ord_module() -> BuiltInModule {
                 }
                 true.into_steelval()
             }
-            _ => panic!("Supposed to be called by ordering functions which ensure arity"),
+            _ => stop!(ArityMismatch => "expected at least one argument"),
         }
     }
 

--- a/crates/steel-core/src/steel_vm/primitives.rs
+++ b/crates/steel-core/src/steel_vm/primitives.rs
@@ -971,7 +971,7 @@ fn ord_module() -> BuiltInModule {
             (SteelVal::IntV(x), SteelVal::Rational(y)) => {
                 #[cfg(target_pointer_width = "32")]
                 {
-                    let x_rational = Rational32::new_raw(x, 1);
+                    let x_rational = num::Rational32::new_raw(*x as i32, 1);
                     x_rational.partial_cmp(y)
                 }
                 #[cfg(target_pointer_width = "64")]
@@ -1019,8 +1019,8 @@ fn ord_module() -> BuiltInModule {
             (SteelVal::Rational(x), SteelVal::IntV(y)) => {
                 #[cfg(target_pointer_width = "32")]
                 {
-                    let y_rational = Rational32::new_raw(y, 1);
-                    x.partial_cmp(y_rational)
+                    let y_rational = num::Rational32::new_raw(*y as i32, 1);
+                    x.partial_cmp(&y_rational)
                 }
                 #[cfg(target_pointer_width = "64")]
                 {

--- a/crates/steel-core/src/tests/success/trie_sort.scm
+++ b/crates/steel-core/src/tests/success/trie_sort.scm
@@ -27,8 +27,8 @@
     ;; children are empty, return list of empty children
     [(empty? lst) (list (trie char empty #t next-prefix))]
     ;; less than, put it to the left
-    [(< char (trie-char (first lst))) (cons (trie char empty #t next-prefix) lst)]
-    [(= char (trie-char (first lst))) ;; equal, step down a level
+    [(char<? char (trie-char (first lst))) (cons (trie char empty #t next-prefix) lst)]
+    [(char=? char (trie-char (first lst))) ;; equal, step down a level
      (cons (trie char (trie-children (first lst)) #t next-prefix) (rest lst))]
     ;; move to the right
     [else (cons (first lst) (create-children char-list (rest lst) prefix-chars))]))
@@ -41,7 +41,7 @@
   (cond
     [(empty? lst) ;; no children, pop off front and step down
      (list (trie char (create-children (rest char-list) empty next-prefix) #f next-prefix))]
-    [(< char (trie-char (first lst))) ;; place where it is, pop off front and go
+    [(char<? char (trie-char (first lst))) ;; place where it is, pop off front and go
      (cons (trie char (create-children (rest char-list) empty next-prefix) #f next-prefix) lst)]
     [(equal? char (trie-char (first lst))) ;; equal, step down
      (cons (trie char
@@ -62,7 +62,7 @@
 
 ; contract: trie? trie? -> boolean?
 (define (trie<? trie-node1 trie-node2)
-  (< (trie-char trie-node1) (trie-char trie-node2)))
+  (char<? (trie-char trie-node1) (trie-char trie-node2)))
 
 ;; contract: trie? (listof string?) -> trie?
 (define (build-trie-from-list-of-words trie list-of-words)

--- a/crates/steel-core/src/tests/success/trie_sort.scm
+++ b/crates/steel-core/src/tests/success/trie_sort.scm
@@ -43,7 +43,7 @@
      (list (trie char (create-children (rest char-list) empty next-prefix) #f next-prefix))]
     [(char<? char (trie-char (first lst))) ;; place where it is, pop off front and go
      (cons (trie char (create-children (rest char-list) empty next-prefix) #f next-prefix) lst)]
-    [(equal? char (trie-char (first lst))) ;; equal, step down
+    [(char=? char (trie-char (first lst))) ;; equal, step down
      (cons (trie char
                  (create-children (rest char-list) (trie-children (first lst)) next-prefix)
                  (trie-end-word? (first lst))

--- a/docs/src/builtins/steel_base.md
+++ b/docs/src/builtins/steel_base.md
@@ -52,6 +52,66 @@ Divides the given numbers.
 > (/ 1 3.0) ;; => 0.3333333333333333
 > (/ 1 3) ;; => 1/3
 ```
+### **<**
+Compares two real numbers to check if the first is less than the second.
+
+(< left right) -> bool?
+
+* left : real? - The first real number to compare.
+* right : real? - The second real number to compare.
+
+#### Examples
+```scheme
+> (< 3 2) ;; => #f
+> (< 2 3) ;; => #t
+> (< 3/2 1.5) ;; => #f
+> (< 2.5 3/2) ;; => #t
+```
+### **<=**
+Compares two real numbers to check if the first is less than or equal to the second.
+
+(<= left right) -> bool?
+
+* left : real? - The first real number to compare.
+* right : real? - The second real number to compare.
+
+#### Examples
+```scheme
+> (<= 3 2) ;; => #f
+> (<= 2 3) ;; => #t
+> (<= 3/2 1.5) ;; => #t
+> (<= 2.5 3/2) ;; => #f
+```
+### **>**
+Compares two real numbers to check if the first is greater than the second.
+
+(> left right) -> bool?
+
+* left : real? - The first real number to compare.
+* right : real? - The second real number to compare.
+
+#### Examples
+```scheme
+> (> 3 2) ;; => #t
+> (> 1 1) ;; => #f
+> (> 3/2 1.5) ;; => #f
+> (> 3/2 1.4) ;; => #t
+```
+### **>=**
+Compares two real numbers to check if the first is greater than or equal to the second.
+
+(>= left right) -> bool?
+
+* left : real? - The first real number to compare.
+* right : real? - The second real number to compare.
+
+#### Examples
+```scheme
+> (>= 3 2) ;; => #t
+> (>= 2 3) ;; => #f
+> (>= 3/2 1.5) ;; => #t
+> (>= 3/2 1.4) ;; => #t
+```
 ### **abs**
 Computes the absolute value of the given number.
 
@@ -1725,11 +1785,7 @@ Checks if the given real number is zero.
 ```
 ### **%iterator?**
 ### **%keyword-hash**
-### **<**
-### **<=**
 ### **=**
-### **>**
-### **>=**
 ### **Engine::add-module**
 ### **Engine::clone**
 ### **Engine::modules->list**
@@ -1881,6 +1937,7 @@ Checks if the given real number is zero.
 ### **spawn-thread!**
 ### **stdout**
 ### **stdout-simple-displayln**
+### **steel-home-location**
 ### **stream-car**
 ### **stream-cons**
 ### **stream-empty?**

--- a/docs/src/builtins/steel_base.md
+++ b/docs/src/builtins/steel_base.md
@@ -53,64 +53,72 @@ Divides the given numbers.
 > (/ 1 3) ;; => 1/3
 ```
 ### **<**
-Compares two real numbers to check if the first is less than the second.
+Compares real numbers to check if any number is less than the subsequent.
 
-(< left right) -> bool?
+(< x . rest) -> bool?
 
-* left : real? - The first real number to compare.
-* right : real? - The second real number to compare.
+* x : real? - The first real number to compare.
+* rest : real? - The rest of the numbers to compare.
 
 #### Examples
 ```scheme
+> (< 1) ;; => #t
 > (< 3 2) ;; => #f
 > (< 2 3) ;; => #t
 > (< 3/2 1.5) ;; => #f
 > (< 2.5 3/2) ;; => #t
+> (< 2 5/2 3) ;; #t
 ```
 ### **<=**
-Compares two real numbers to check if the first is less than or equal to the second.
+Compares real numbers to check if any number is less than or equal than the subsequent.
 
-(<= left right) -> bool?
+(<= x . rest) -> bool?
 
-* left : real? - The first real number to compare.
-* right : real? - The second real number to compare.
+* x : real? - The first real number to compare.
+* rest : real? - The rest of the numbers to compare.
 
 #### Examples
 ```scheme
+> (<= 1) ;; => #t
 > (<= 3 2) ;; => #f
 > (<= 2 3) ;; => #t
 > (<= 3/2 1.5) ;; => #t
 > (<= 2.5 3/2) ;; => #f
+> (<= 2 6/2 3) ;; #t
 ```
 ### **>**
-Compares two real numbers to check if the first is greater than the second.
+Compares real numbers to check if any number is greater than the subsequent.
 
-(> left right) -> bool?
+(> x . rest) -> bool?
 
-* left : real? - The first real number to compare.
-* right : real? - The second real number to compare.
+* x : real? - The first real number to compare.
+* rest : real? - The rest of the numbers to compare.
 
 #### Examples
 ```scheme
+> (> 1) ;; => #t
 > (> 3 2) ;; => #t
 > (> 1 1) ;; => #f
 > (> 3/2 1.5) ;; => #f
 > (> 3/2 1.4) ;; => #t
+> (> 3 4/2 1) ;; #t
 ```
 ### **>=**
-Compares two real numbers to check if the first is greater than or equal to the second.
+Compares real numbers to check if any number is greater than or equal than the subsequent.
 
-(>= left right) -> bool?
+(>= x . rest) -> bool?
 
-* left : real? - The first real number to compare.
-* right : real? - The second real number to compare.
+* x : real? - The first real number to compare.
+* rest : real? - The rest of the numbers to compare.
 
 #### Examples
 ```scheme
+> (>= 1) ;; => #t
 > (>= 3 2) ;; => #t
 > (>= 2 3) ;; => #f
 > (>= 3/2 1.5) ;; => #t
 > (>= 3/2 1.4) ;; => #t
+> (>= 2 4/2 1) ;; #t
 ```
 ### **abs**
 Computes the absolute value of the given number.

--- a/docs/src/builtins/steel_meta.md
+++ b/docs/src/builtins/steel_meta.md
@@ -49,6 +49,7 @@ Returns the message of an error object.
 ### **set-env-var!**
 ### **set-strong-box!**
 ### **set-test-mode!**
+### **steel-home-location**
 ### **struct->list**
 ### **unbox**
 ### **unbox-strong**

--- a/docs/src/builtins/steel_ord.md
+++ b/docs/src/builtins/steel_ord.md
@@ -1,5 +1,62 @@
 # steel/ord
+Real numbers ordering module.
 ### **<**
+Compares two real numbers to check if the first is less than the second.
+
+(< left right) -> bool?
+
+* left : real? - The first real number to compare.
+* right : real? - The second real number to compare.
+
+#### Examples
+```scheme
+> (< 3 2) ;; => #f
+> (< 2 3) ;; => #t
+> (< 3/2 1.5) ;; => #f
+> (< 2.5 3/2) ;; => #t
+```
 ### **<=**
+Compares two real numbers to check if the first is less than or equal to the second.
+
+(<= left right) -> bool?
+
+* left : real? - The first real number to compare.
+* right : real? - The second real number to compare.
+
+#### Examples
+```scheme
+> (<= 3 2) ;; => #f
+> (<= 2 3) ;; => #t
+> (<= 3/2 1.5) ;; => #t
+> (<= 2.5 3/2) ;; => #f
+```
 ### **>**
+Compares two real numbers to check if the first is greater than the second.
+
+(> left right) -> bool?
+
+* left : real? - The first real number to compare.
+* right : real? - The second real number to compare.
+
+#### Examples
+```scheme
+> (> 3 2) ;; => #t
+> (> 1 1) ;; => #f
+> (> 3/2 1.5) ;; => #f
+> (> 3/2 1.4) ;; => #t
+```
 ### **>=**
+Compares two real numbers to check if the first is greater than or equal to the second.
+
+(>= left right) -> bool?
+
+* left : real? - The first real number to compare.
+* right : real? - The second real number to compare.
+
+#### Examples
+```scheme
+> (>= 3 2) ;; => #t
+> (>= 2 3) ;; => #f
+> (>= 3/2 1.5) ;; => #t
+> (>= 3/2 1.4) ;; => #t
+```

--- a/docs/src/builtins/steel_ord.md
+++ b/docs/src/builtins/steel_ord.md
@@ -1,62 +1,70 @@
 # steel/ord
 Real numbers ordering module.
 ### **<**
-Compares two real numbers to check if the first is less than the second.
+Compares real numbers to check if any number is less than the subsequent.
 
-(< left right) -> bool?
+(< x . rest) -> bool?
 
-* left : real? - The first real number to compare.
-* right : real? - The second real number to compare.
+* x : real? - The first real number to compare.
+* rest : real? - The rest of the numbers to compare.
 
 #### Examples
 ```scheme
+> (< 1) ;; => #t
 > (< 3 2) ;; => #f
 > (< 2 3) ;; => #t
 > (< 3/2 1.5) ;; => #f
 > (< 2.5 3/2) ;; => #t
+> (< 2 5/2 3) ;; #t
 ```
 ### **<=**
-Compares two real numbers to check if the first is less than or equal to the second.
+Compares real numbers to check if any number is less than or equal than the subsequent.
 
-(<= left right) -> bool?
+(<= x . rest) -> bool?
 
-* left : real? - The first real number to compare.
-* right : real? - The second real number to compare.
+* x : real? - The first real number to compare.
+* rest : real? - The rest of the numbers to compare.
 
 #### Examples
 ```scheme
+> (<= 1) ;; => #t
 > (<= 3 2) ;; => #f
 > (<= 2 3) ;; => #t
 > (<= 3/2 1.5) ;; => #t
 > (<= 2.5 3/2) ;; => #f
+> (<= 2 6/2 3) ;; #t
 ```
 ### **>**
-Compares two real numbers to check if the first is greater than the second.
+Compares real numbers to check if any number is greater than the subsequent.
 
-(> left right) -> bool?
+(> x . rest) -> bool?
 
-* left : real? - The first real number to compare.
-* right : real? - The second real number to compare.
+* x : real? - The first real number to compare.
+* rest : real? - The rest of the numbers to compare.
 
 #### Examples
 ```scheme
+> (> 1) ;; => #t
 > (> 3 2) ;; => #t
 > (> 1 1) ;; => #f
 > (> 3/2 1.5) ;; => #f
 > (> 3/2 1.4) ;; => #t
+> (> 3 4/2 1) ;; #t
 ```
 ### **>=**
-Compares two real numbers to check if the first is greater than or equal to the second.
+Compares real numbers to check if any number is greater than or equal than the subsequent.
 
-(>= left right) -> bool?
+(>= x . rest) -> bool?
 
-* left : real? - The first real number to compare.
-* right : real? - The second real number to compare.
+* x : real? - The first real number to compare.
+* rest : real? - The rest of the numbers to compare.
 
 #### Examples
 ```scheme
+> (>= 1) ;; => #t
 > (>= 3 2) ;; => #t
 > (>= 2 3) ;; => #f
 > (>= 3/2 1.5) ;; => #t
 > (>= 3/2 1.4) ;; => #t
+> (>= 2 4/2 1) ;; #t
 ```


### PR DESCRIPTION
Hey,
I'm not sure what is the goal regarding consistency with Scheme, but according to Racket docs for `>`, `<`, `>=` and `<=` functions both args shall be `real?`. Also things like `(< 1337 "leet")` didn't fail either.

This PR updates `steel/ord` module for real numbers comparison as well as adds missing documentation.

P.S. I tried to implement something like numeric tower as well to promote types in some more typesafe way to possibly reuse it in other modules, but failed miserably, shall be a separate effort I suppose, going the most direct way now.