### PR TITLE
simplify `flake.nix`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -34,10 +34,6 @@
           };
           cargoLock = {
             lockFile = ./Cargo.lock;
-            # Temporary fix until https://github.com/mattwparas/steel/issues/192 is fixed upstream
-            outputHashes = {
-              "lasso-0.7.2" = "sha256-ccqcDvWZD5hp4iZ420jgNJtR+MaVlqHFtXU2GWkbyfg=";
-            };
           };
           cargoBuildFlags = "-p cargo-steel-lib -p steel-interpreter";
           buildInputs = [openssl] ++ lib.optionals stdenv.isDarwin [darwin.apple_sdk.frameworks.Security];

--- a/flake.nix
+++ b/flake.nix
@@ -36,7 +36,7 @@
             lockFile = ./Cargo.lock;
             # Temporary fix until https://github.com/mattwparas/steel/issues/192 is fixed upstream
             outputHashes = {
-              "lasso-0.7.2" = "sha256-ibpHfge3nEtwLNghKEQT7ZpTe5kgDf8hbBb9qYHyHcQ=";
+              "lasso-0.7.2" = "sha256-ccqcDvWZD5hp4iZ420jgNJtR+MaVlqHFtXU2GWkbyfg=";
             };
           };
           cargoBuildFlags = "-p cargo-steel-lib -p steel-interpreter";


### PR DESCRIPTION
I'll confess to not really knowing what's going on here.  I just saw that there was a flake.nix here, so I dropped into a devshell and got an error about a hash mismatch. This PR updates it to the "correct" hash according to my experience.

Thought you might like to know, sorry I can't provide more context--I'm new to this project, although I'm looking forward to getting to know it better.