### PR TITLE
ci: build multi arch docker images using buildx

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,8 +2,9 @@ name: Docker CI
 
 on:
   push:
-    # runs on every commit
-    branches: ["master"]
+    branches:
+      - master
+  pull_request:
 
 permissions:
   contents: read
@@ -15,11 +16,29 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Build the docker image
-        run: docker build -t steelscheme/steel:latest .
-
       - name: Authenticate to the Docker Hub
-        run: docker login -u steelscheme -p ${{ secrets.DOCKER_HUB_PWD }}
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: docker/login-action@v3
+        with:
+          username: steelscheme
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Push the docker image
-        run: docker push steelscheme/steel:latest
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # disable push on merge requests
+      - name: Test Build
+        uses: docker/build-push-action@v6
+        if: ${{ github.event_name == 'pull_request' }}
+        with:
+          push: false
+          platforms: linux/amd64,linux/arm64
+          tags: steelscheme/steel:latest
+
+      - name: Build and push the docker image
+        uses: docker/build-push-action@v6
+        if: ${{ github.event_name != 'pull_request' }}
+        with:
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: steelscheme/steel:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:slim as build
+FROM rust:slim AS build
 
 COPY . /steel/
 
@@ -16,13 +16,14 @@ RUN mkdir -p /lib/steel/
 ENV STEEL_HOME="/lib/steel"
 
 RUN cargo build --release
+
 RUN cargo install --path crates/cargo-steel-lib
 
 RUN cd cogs && cargo run -- install.scm
 
 FROM rust:slim
 
-COPY --from=build /steel/target/debug/steel /usr/local/bin
+COPY --from=build /steel/target/release/steel /usr/local/bin
 
 COPY --from=build /lib/steel /lib/
 


### PR DESCRIPTION
- using buildx to also build docker image for arm64 platform
- ignore docker login in pull requests
- use official docker github action for dockerhub authentication