### PR TITLE
strip the release binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,3 +49,4 @@ members = [
 # debug = false
 debug = true
 lto = true
+strip = true


### PR DESCRIPTION
set option to strip the binary in release mode. Helps reduce the binary size as well as the docker image size