### PR TITLE
[WIP] Use CompactString as backing storage for Steel strings.

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -28,7 +28,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: dtolnay/rust-toolchain@nightly
-    - run: cd crates/steel-core && cargo bench --bench my_benchmark -- --output-format bencher | tee output.txt
+    - run: |
+        cd crates/steel-core
+        cargo bench --bench my_benchmark -- --output-format bencher | tee output.txt
     - uses: actions/cache@v1
       with:
         path: ./cache

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,6 +418,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2698f953def977c68f935bb0dfa959375ad4638570e969e2f1e9f433cbf1af6"
 
 [[package]]
+name = "castaway"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0abae9be0aaf9ea96a3b1b8b1b55c602ca751eba1b1500220cea4ecbafe7c0d5"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -552,6 +561,20 @@ checksum = "cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8"
 dependencies = [
  "lazy_static",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6050c3a16ddab2e412160b31f2c871015704239bca62f72f6e5f0be631d3f644"
+dependencies = [
+ "castaway 0.2.3",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
 ]
 
 [[package]]
@@ -1554,7 +1577,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "334e04b4d781f436dc315cb1e7515bd96826426345d498149e4bde36b67f8ee9"
 dependencies = [
  "async-channel 1.9.0",
- "castaway",
+ "castaway 0.1.2",
  "crossbeam-utils",
  "curl",
  "curl-sys",
@@ -2905,6 +2928,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "steel-async-webrequests"
 version = "0.6.0"
 dependencies = [
@@ -2928,6 +2957,7 @@ dependencies = [
  "cargo-steel-lib",
  "chrono",
  "codespan-reporting",
+ "compact_str",
  "cranelift",
  "cranelift-jit",
  "cranelift-module",

--- a/crates/steel-core/Cargo.toml
+++ b/crates/steel-core/Cargo.toml
@@ -48,8 +48,9 @@ rand = "0.8.5"
 num = "0.4.0"
 radix_fmt = "1.0.0"
 
-# For structs
+# Optimized datastructures
 smallvec = { version = "1.13.0" }
+compact_str = { version = "0.8.0" }
 
 # Pretty printing documentation
 termimad = { version = "0.21.0", optional = true }

--- a/crates/steel-core/src/compiler/code_gen.rs
+++ b/crates/steel-core/src/compiler/code_gen.rs
@@ -23,6 +23,7 @@ use crate::{
         tryfrom_visitor::TryFromExprKindForSteelVal,
         visitors::VisitorMut,
     },
+    rvals::SteelString,
     stop, SteelVal,
 };
 use smallvec::SmallVec;
@@ -56,7 +57,7 @@ fn try_eval_atom(t: &SyntaxObject) -> Option<SteelVal> {
     match &t.ty {
         TokenType::BooleanLiteral(b) => Some((*b).into()),
         TokenType::Number(n) => number_literal_to_steel(n).ok(),
-        TokenType::StringLiteral(s) => Some(SteelVal::StringV(s.to_string().into())),
+        TokenType::StringLiteral(s) => Some(SteelVal::StringV(SteelString::from(s.as_str()))),
         TokenType::CharacterLiteral(c) => Some(SteelVal::CharV(*c)),
         // TODO: Keywords shouldn't be misused as an expression - only in function calls are keywords allowed
         TokenType::Keyword(k) => Some(SteelVal::SymbolV(k.clone().into())),
@@ -70,7 +71,7 @@ fn try_eval_atom_with_context(t: &SyntaxObject) -> Result<SteelVal> {
     match &t.ty {
         TokenType::BooleanLiteral(b) => Ok((*b).into()),
         TokenType::Number(n) => number_literal_to_steel(n).map_err(|e| e.with_span(t.span)),
-        TokenType::StringLiteral(s) => Ok(SteelVal::StringV(s.to_string().into())),
+        TokenType::StringLiteral(s) => Ok(SteelVal::StringV(SteelString::from(s.as_str()))),
         TokenType::CharacterLiteral(c) => Ok(SteelVal::CharV(*c)),
         TokenType::Keyword(k) => Ok(SteelVal::SymbolV(k.clone().into())),
         _what => {

--- a/crates/steel-core/src/compiler/program.rs
+++ b/crates/steel-core/src/compiler/program.rs
@@ -76,7 +76,7 @@ fn eval_atom(t: &SyntaxObject) -> Result<SteelVal> {
     match &t.ty {
         TokenType::BooleanLiteral(b) => Ok((*b).into()),
         TokenType::Number(n) => number_literal_to_steel(n),
-        TokenType::StringLiteral(s) => Ok(SteelVal::StringV(s.to_string().into())),
+        TokenType::StringLiteral(s) => Ok(SteelVal::StringV(s.as_str().into())),
         TokenType::CharacterLiteral(c) => Ok(SteelVal::CharV(*c)),
         // TODO: Keywords shouldn't be misused as an expression - only in function calls are keywords allowed
         TokenType::Keyword(k) => Ok(SteelVal::SymbolV(k.clone().into())),

--- a/crates/steel-core/src/gc.rs
+++ b/crates/steel-core/src/gc.rs
@@ -13,6 +13,7 @@ use std::{ffi::OsStr, fmt};
 pub static OBJECT_COUNT: AtomicUsize = AtomicUsize::new(0);
 pub(crate) static MAXIMUM_OBJECTS: usize = 50000;
 
+use compact_str::CompactString;
 pub use shared::{GcMut, MutContainer, ShareableMut, Shared, SharedMut};
 
 #[cfg(feature = "sync")]
@@ -447,31 +448,31 @@ impl<T: ?Sized> Clone for Gc<T> {
     }
 }
 
-impl AsRef<OsStr> for Gc<String> {
+impl AsRef<OsStr> for Gc<CompactString> {
     fn as_ref(&self) -> &OsStr {
         self.0.as_ref().as_ref()
     }
 }
 
-impl From<&str> for Gc<String> {
+impl From<&str> for Gc<CompactString> {
     fn from(val: &str) -> Self {
-        Gc::new(val.to_string())
+        Gc::new(val.into())
     }
 }
 
-impl From<String> for Gc<String> {
-    fn from(val: String) -> Self {
+impl From<CompactString> for Gc<CompactString> {
+    fn from(val: CompactString) -> Self {
         Gc::new(val)
     }
 }
 
-impl From<&String> for Gc<String> {
-    fn from(val: &String) -> Self {
+impl From<&CompactString> for Gc<CompactString> {
+    fn from(val: &CompactString) -> Self {
         Gc::new(val.clone())
     }
 }
 
-impl AsRef<str> for Gc<String> {
+impl AsRef<str> for Gc<CompactString> {
     fn as_ref(&self) -> &str {
         self.0.as_ref()
     }

--- a/crates/steel-core/src/parser/kernel.rs
+++ b/crates/steel-core/src/parser/kernel.rs
@@ -3,6 +3,7 @@ use std::{
     sync::{Arc, RwLock},
 };
 
+use compact_str::{format_compact, ToCompactString};
 use fxhash::{FxBuildHasher, FxHashMap, FxHashSet};
 
 #[cfg(feature = "sync")]
@@ -114,7 +115,7 @@ impl Kernel {
                     .map(|set| {
                         set.iter()
                             .map(|x| x.resolve().to_string())
-                            .map(|x| SteelVal::SymbolV(x.into()))
+                            .map(|x| SteelVal::SymbolV(x.as_str().into()))
                             .collect::<crate::values::lists::List<SteelVal>>()
                             .into()
                     })
@@ -551,8 +552,9 @@ impl Kernel {
         } else {
             // Check if there is anything to expand in this environment
             if let Ok(SteelVal::HashMapV(map)) = self.engine.extract_value(environment) {
-                if let Some(func) = map.get(&SteelVal::SymbolV(ident.resolve().to_string().into()))
-                {
+                if let Some(func) = map.get(&SteelVal::SymbolV(SteelString::from(
+                    ident.resolve().to_compact_string(),
+                ))) {
                     func.clone()
                 } else {
                     self.engine.extract_value(ident.resolve())?

--- a/crates/steel-core/src/parser/parser.rs
+++ b/crates/steel-core/src/parser/parser.rs
@@ -178,7 +178,7 @@ impl TryFrom<SyntaxObject> for SteelVal {
                 }
                 .into_steelval(),
             },
-            StringLiteral(x) => Ok(StringV((*x).into())),
+            StringLiteral(x) => Ok(StringV((*x).as_str().into())),
             Keyword(x) => Ok(SymbolV(x.into())),
             QuoteTick => {
                 Err(SteelErr::new(ErrorKind::UnexpectedToken, "'".to_string()).with_span(span))

--- a/crates/steel-core/src/primitives.rs
+++ b/crates/steel-core/src/primitives.rs
@@ -377,7 +377,7 @@ impl TryFrom<&SteelVal> for String {
 
 impl From<String> for SteelVal {
     fn from(val: String) -> SteelVal {
-        SteelVal::StringV(val.into())
+        SteelVal::StringV(val.as_str().into())
     }
 }
 
@@ -819,7 +819,7 @@ impl<'a> PrimitiveAsRef<'a> for &'a SteelHashMap {
 
 impl IntoSteelVal for String {
     fn into_steelval(self) -> Result<SteelVal, SteelErr> {
-        Ok(SteelVal::StringV(self.into()))
+        Ok(SteelVal::StringV(self.as_str().into()))
     }
 }
 

--- a/crates/steel-core/src/primitives/control.rs
+++ b/crates/steel-core/src/primitives/control.rs
@@ -13,7 +13,7 @@ impl ControlOperations {
                 error_message.push_str(error_val.trim_matches('\"'));
             }
 
-            Ok(SteelVal::StringV(error_message.into()))
+            Ok(SteelVal::StringV(error_message.as_str().into()))
         })
     }
 

--- a/crates/steel-core/src/primitives/lists.rs
+++ b/crates/steel-core/src/primitives/lists.rs
@@ -628,7 +628,7 @@ fn list_to_string(list: &List<SteelVal>) -> Result<SteelVal> {
             x.char_or_else(throw!(TypeMismatch => "list->string expected a list of characters"))
         })
         .collect::<Result<String>>()
-        .map(|x| x.into())
+        .map(|x| x.as_str().into())
         .map(SteelVal::StringV)
 }
 

--- a/crates/steel-core/src/primitives/ports.rs
+++ b/crates/steel-core/src/primitives/ports.rs
@@ -176,7 +176,7 @@ pub fn open_input_bytevector(bytes: &SteelByteVector) -> SteelVal {
 #[function(name = "read-port-to-string")]
 pub fn read_port_to_string(port: &SteelPort) -> Result<SteelVal> {
     let (_, result) = port.read_all_str()?;
-    Ok(SteelVal::StringV(result.into()))
+    Ok(SteelVal::StringV(result.as_str().into()))
 }
 
 /// Checks if a given value is an input port
@@ -225,7 +225,7 @@ pub fn read_line_to_string(port: &SteelPort) -> Result<SteelVal> {
         if size == 0 {
             Ok(eof())
         } else {
-            Ok(SteelVal::StringV(result.into()))
+            Ok(SteelVal::StringV(result.as_str().into()))
         }
     } else {
         // bit of a hack for now we'll see

--- a/crates/steel-core/src/primitives/symbols.rs
+++ b/crates/steel-core/src/primitives/symbols.rs
@@ -17,7 +17,7 @@ impl SymbolOperations {
                 }
             }
 
-            Ok(SteelVal::SymbolV(new_symbol.into()))
+            Ok(SteelVal::SymbolV(new_symbol.as_str().into()))
         })
     }
 

--- a/crates/steel-core/src/primitives/vectors.rs
+++ b/crates/steel-core/src/primitives/vectors.rs
@@ -77,7 +77,7 @@ fn immutable_vector_to_string(
             x.char_or_else(throw!(TypeMismatch => "immutable-vector->string expected a succession of characters"))
         })
         .collect::<Result<String>>()
-        .map(|x| x.into())
+        .map(|x| x.as_str().into())
         .map(SteelVal::StringV)
 }
 

--- a/crates/steel-core/src/rvals.rs
+++ b/crates/steel-core/src/rvals.rs
@@ -67,6 +67,7 @@ macro_rules! list {
 }
 
 use bigdecimal::BigDecimal;
+use compact_str::CompactString;
 use SteelVal::*;
 
 use crate::values::{HashMap, HashSet, Vector};
@@ -897,7 +898,7 @@ pub fn from_serializable_value(ctx: &mut HeapSerializer, val: SerializableSteelV
         SerializableSteelVal::CharV(c) => SteelVal::CharV(c),
         SerializableSteelVal::Void => SteelVal::Void,
         SerializableSteelVal::Rational(r) => SteelVal::Rational(r),
-        SerializableSteelVal::StringV(s) => SteelVal::StringV(s.into()),
+        SerializableSteelVal::StringV(s) => SteelVal::StringV(s.as_str().into()),
         SerializableSteelVal::FuncV(f) => SteelVal::FuncV(f),
         SerializableSteelVal::MutFunc(f) => SteelVal::MutFunc(f),
         SerializableSteelVal::HashMapV(h) => SteelVal::HashMapV(
@@ -925,7 +926,7 @@ pub fn from_serializable_value(ctx: &mut HeapSerializer, val: SerializableSteelV
         ))),
         SerializableSteelVal::BoxedDynFunction(f) => SteelVal::BoxedFunction(Gc::new(f)),
         SerializableSteelVal::BuiltIn(f) => SteelVal::BuiltIn(f),
-        SerializableSteelVal::SymbolV(s) => SteelVal::SymbolV(s.into()),
+        SerializableSteelVal::SymbolV(s) => SteelVal::SymbolV(s.as_str().into()),
         SerializableSteelVal::Custom(b) => SteelVal::Custom(Gc::new_mut(b)),
         SerializableSteelVal::CustomStruct(s) => {
             SteelVal::CustomStruct(Gc::new(UserDefinedStruct {
@@ -1539,10 +1540,10 @@ impl SteelVal {
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
-pub struct SteelString(Gc<String>);
+pub struct SteelString(Gc<CompactString>);
 
 impl Deref for SteelString {
-    type Target = crate::gc::Shared<String>;
+    type Target = crate::gc::Shared<CompactString>;
 
     fn deref(&self) -> &Self::Target {
         &self.0 .0
@@ -1551,41 +1552,41 @@ impl Deref for SteelString {
 
 impl From<&str> for SteelString {
     fn from(val: &str) -> Self {
-        SteelString(Gc::new(val.to_string()))
+        SteelString(Gc::new(val.into()))
     }
 }
 
-impl From<&String> for SteelString {
-    fn from(val: &String) -> Self {
-        SteelString(Gc::new(val.to_owned()))
+impl From<&CompactString> for SteelString {
+    fn from(val: &CompactString) -> Self {
+        SteelString(Gc::new(val.clone()))
     }
 }
 
-impl From<String> for SteelString {
-    fn from(val: String) -> Self {
+impl From<CompactString> for SteelString {
+    fn from(val: CompactString) -> Self {
         SteelString(Gc::new(val))
     }
 }
 
-impl From<crate::gc::Shared<String>> for SteelString {
-    fn from(val: crate::gc::Shared<String>) -> Self {
+impl From<crate::gc::Shared<CompactString>> for SteelString {
+    fn from(val: crate::gc::Shared<CompactString>) -> Self {
         SteelString(Gc(val))
     }
 }
 
-impl From<Gc<String>> for SteelString {
-    fn from(val: Gc<String>) -> Self {
+impl From<Gc<CompactString>> for SteelString {
+    fn from(val: Gc<CompactString>) -> Self {
         SteelString(val)
     }
 }
 
-impl From<SteelString> for crate::gc::Shared<String> {
+impl From<SteelString> for crate::gc::Shared<CompactString> {
     fn from(value: SteelString) -> Self {
         value.0 .0
     }
 }
 
-impl From<SteelString> for Gc<String> {
+impl From<SteelString> for Gc<CompactString> {
     fn from(value: SteelString) -> Self {
         value.0
     }

--- a/crates/steel-core/src/steel_vm/builtin.rs
+++ b/crates/steel-core/src/steel_vm/builtin.rs
@@ -298,7 +298,7 @@ impl BuiltInModuleRepr {
     pub fn bound_identifiers(&self) -> crate::values::lists::List<SteelVal> {
         self.values
             .keys()
-            .map(|x| SteelVal::StringV(x.to_string().into()))
+            .map(|x| SteelVal::StringV(x.to_string().as_str().into()))
             .collect()
     }
 

--- a/crates/steel-core/src/steel_vm/const_evaluation.rs
+++ b/crates/steel-core/src/steel_vm/const_evaluation.rs
@@ -293,7 +293,7 @@ impl<'a> ConstantEvaluator<'a> {
             }
             // todo!() figure out if it is ok to expand scope of eval_atom.
             TokenType::Number(n) => number_literal_to_steel(n).ok(),
-            TokenType::StringLiteral(s) => Some(SteelVal::StringV((*s.clone()).into())),
+            TokenType::StringLiteral(s) => Some(SteelVal::StringV((*s.clone()).as_str().into())),
             TokenType::CharacterLiteral(c) => Some(SteelVal::CharV(*c)),
             _ => None,
         }

--- a/crates/steel-core/src/steel_vm/engine.rs
+++ b/crates/steel-core/src/steel_vm/engine.rs
@@ -61,6 +61,7 @@ use std::{
 };
 
 use crate::values::HashMap as ImmutableHashMap;
+use compact_str::ToCompactString;
 use fxhash::{FxBuildHasher, FxHashMap};
 use lasso::ThreadedRodeo;
 use once_cell::sync::OnceCell;
@@ -1481,7 +1482,7 @@ impl Engine {
             match &t.ty {
                 TokenType::BooleanLiteral(b) => Ok((*b).into()),
                 TokenType::Number(n) => number_literal_to_steel(n),
-                TokenType::StringLiteral(s) => Ok(SteelVal::StringV(s.to_string().into())),
+                TokenType::StringLiteral(s) => Ok(SteelVal::StringV(s.to_compact_string().into())),
                 TokenType::CharacterLiteral(c) => Ok(SteelVal::CharV(*c)),
                 // TODO: Keywords shouldn't be misused as an expression - only in function calls are keywords allowed
                 TokenType::Keyword(k) => Ok(SteelVal::SymbolV(k.clone().into())),

--- a/crates/steel-core/src/steel_vm/ffi.rs
+++ b/crates/steel-core/src/steel_vm/ffi.rs
@@ -25,6 +25,7 @@ use abi_stable::{
     },
     RMut, StableAbi,
 };
+use compact_str::ToCompactString;
 use futures_util::FutureExt;
 
 use crate::values::HashMap;
@@ -1103,7 +1104,7 @@ impl FFIValue {
             Self::CharV { c } => Ok(SteelVal::CharV(*c)),
             Self::Void => Ok(SteelVal::Void),
             // TODO: I think this might clone the string, its also a little suspect
-            Self::StringV(s) => Ok(SteelVal::StringV(s.to_string().into())),
+            Self::StringV(s) => Ok(SteelVal::StringV(s.to_compact_string().into())),
             Self::Vector(v) => v
                 .into_iter()
                 .map(|x| x.as_steelval())
@@ -1155,8 +1156,7 @@ impl IntoSteelVal for FFIValue {
             Self::IntV(i) => Ok(SteelVal::IntV(i)),
             Self::CharV { c } => Ok(SteelVal::CharV(c)),
             Self::Void => Ok(SteelVal::Void),
-            // TODO: I think this might clone the string, its also a little suspect
-            Self::StringV(s) => Ok(SteelVal::StringV(s.into_string().into())),
+            Self::StringV(s) => Ok(SteelVal::StringV(s.as_str().to_compact_string().into())),
             Self::Vector(v) => v
                 .into_iter()
                 .map(|x| x.into_steelval())

--- a/crates/steel-core/src/steel_vm/meta.rs
+++ b/crates/steel-core/src/steel_vm/meta.rs
@@ -231,7 +231,7 @@ pub fn eval(program: String) -> List<SteelVal> {
     match res {
         Ok(v) => vec![
             SteelVal::ListV(v.into()),
-            SteelVal::StringV(drain_custom_output_port().into()),
+            SteelVal::StringV(drain_custom_output_port().as_str().into()),
             SteelVal::StringV("".into()),
         ]
         .into(),
@@ -240,8 +240,8 @@ pub fn eval(program: String) -> List<SteelVal> {
 
             vec![
                 SteelVal::ListV(List::new()),
-                SteelVal::StringV(drain_custom_output_port().into()),
-                SteelVal::StringV(report.into()),
+                SteelVal::StringV(drain_custom_output_port().as_str().into()),
+                SteelVal::StringV(report.as_str().into()),
             ]
             .into()
         }

--- a/crates/steel-core/src/values/json_vals.rs
+++ b/crates/steel-core/src/values/json_vals.rs
@@ -43,7 +43,7 @@ pub fn string_to_jsexpr(value: &SteelString) -> Result<SteelVal> {
 pub fn serialize_val_to_string(value: SteelVal) -> Result<SteelVal> {
     let serde_value: Value = value.try_into()?;
     let serialized_value = serde_value.to_string();
-    Ok(SteelVal::StringV(serialized_value.into()))
+    Ok(SteelVal::StringV(serialized_value.as_str().into()))
 }
 
 // required to parse each string
@@ -81,7 +81,7 @@ impl TryFrom<Map<String, Value>> for SteelVal {
     fn try_from(map: Map<String, Value>) -> std::result::Result<Self, Self::Error> {
         let mut hm = HashMap::new();
         for (key, value) in map {
-            hm.insert(SteelVal::SymbolV(key.into()), value.try_into()?);
+            hm.insert(SteelVal::SymbolV(key.as_str().into()), value.try_into()?);
         }
         Ok(SteelVal::HashMapV(Gc::new(hm).into()))
     }
@@ -94,7 +94,7 @@ impl TryFrom<Value> for SteelVal {
             Value::Null => Ok(SteelVal::Void),
             Value::Bool(t) => Ok(SteelVal::BoolV(t)),
             Value::Number(n) => <SteelVal>::try_from(n),
-            Value::String(s) => Ok(SteelVal::StringV(s.into())),
+            Value::String(s) => Ok(SteelVal::StringV(s.as_str().into())),
             Value::Array(v) => Ok(SteelVal::ListV(
                 v.into_iter()
                     .map(<SteelVal>::try_from)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,7 @@ pub fn run(clap_args: Args) -> Result<(), Box<dyn Error>> {
                 steel::SteelVal::ListV(
                     arguments
                         .into_iter()
-                        .map(|x| steel::SteelVal::StringV(x.into()))
+                        .map(|x| steel::SteelVal::StringV(x.as_str().into()))
                         .collect(),
                 ),
             );


### PR DESCRIPTION
- [x] Use `CompactString`.
- [ ] Benchmark.