### PR TITLE
Added change-current-directory and parent-name to fs

### DIFF
--- a/crates/steel-core/src/primitives/fs.rs
+++ b/crates/steel-core/src/primitives/fs.rs
@@ -2,7 +2,7 @@ use crate::rvals::{Custom, Result, SteelString, SteelVal};
 use crate::steel_vm::builtin::BuiltInModule;
 use crate::{steelerr, stop, throw};
 use dirs;
-use std::env::current_dir;
+use std::env::{current_dir, set_current_dir};
 use std::path::{Path, PathBuf};
 
 use std::fs;
@@ -50,8 +50,10 @@ pub fn fs_module() -> BuiltInModule {
         .register_native_fn_definition(READ_DIR_DEFINITION)
         .register_native_fn_definition(PATH_EXISTS_DEFINITION)
         .register_native_fn_definition(FILE_NAME_DEFINITION)
+        .register_native_fn_definition(PARENT_NAME_DEFINITION)
         .register_native_fn_definition(CANONICALIZE_PATH_DEFINITION)
         .register_native_fn_definition(CURRENT_DIRECTORY_DEFINITION)
+        .register_native_fn_definition(CHANGE_CURRENT_DIRECTORY_DEFINITION)
         .register_native_fn_definition(GET_EXTENSION_DEFINITION)
         .register_native_fn_definition(DELETE_FILE_DEFINITION);
     module
@@ -128,6 +130,18 @@ pub fn file_name(path: &SteelString) -> Result<SteelVal> {
     ))
 }
 
+/// Gets the parent directory name for a given path
+#[steel_derive::function(name = "parent-name")]
+pub fn parent_name(path: &SteelString) -> Result<SteelVal> {
+    Ok(SteelVal::StringV(
+        Path::new(path.as_str())
+            .parent()
+            .and_then(|x| x.to_str())
+            .unwrap_or("")
+            .into(),
+    ))
+}
+
 /// Returns canonical path with all components normalized
 #[steel_derive::function(name = "canonicalize-path")]
 pub fn canonicalize_path(path: &SteelString) -> Result<SteelVal> {
@@ -181,6 +195,15 @@ pub fn read_dir(path: &SteelString) -> Result<SteelVal> {
 pub fn current_directory() -> Result<SteelVal> {
     let path = current_dir()?;
     Ok(SteelVal::StringV(path.to_str().unwrap_or("").into()))
+}
+
+/// Change the current working directory
+#[steel_derive::function(name = "change-current-directory!")]
+pub fn change_current_directory(path: &SteelString) -> Result<SteelVal> {
+    let path = Path::new(path.as_ref());
+
+    set_current_dir(path)?;
+    Ok(SteelVal::Void)
 }
 
 /// Deletes the file

--- a/docs/src/builtins/steel_base.md
+++ b/docs/src/builtins/steel_base.md
@@ -335,6 +335,9 @@ Rounds the given number up to the nearest integer not less than it.
 > (ceiling 42.1) ;; => 43
 > (ceiling -42.1) ;; => -42
 ```
+
+### **change-current-directory!**
+Change the current working directory
 ### **char->integer**
 Returns the Unicode codepoint of a given character.
 
@@ -1190,6 +1193,8 @@ Checks if the given value can be treated as a pair.
 > (pair? '(10)) ;; => #true
 > (pair? '()) ;; => #false
 ```
+### **parent-name**
+Gets the parent directory name for a given path
 ### **path->extension**
 Gets the extension from a path
 ### **path-exists?**

--- a/docs/src/builtins/steel_filesystem.md
+++ b/docs/src/builtins/steel_filesystem.md
@@ -9,12 +9,16 @@ Recursively copies the directory from source to destination
 Creates the directory
 ### **current-directory**
 Check the current working directory
+### **change-current-directory!**
+Change the current working directory
 ### **delete-directory!**
 Deletes the directory
 ### **delete-file!**
 Deletes the file
 ### **file-name**
 Gets the filename for a given path
+### **parent-name**
+Gets the parent directory name for a given path
 ### **is-dir?**
 Checks if a path is a directory
 ### **is-file?**

--- a/flake.nix
+++ b/flake.nix
@@ -68,7 +68,7 @@
           shellHook = ''
             export STEEL_HOME="${steel}/lib/"
           '';
-          buildInputs = [cargo openssl libiconv] ++ lib.optionals stdenv.isDarwin [
+          buildInputs = [cargo rustc openssl libiconv] ++ lib.optionals stdenv.isDarwin [
             darwin.apple_sdk.frameworks.CoreServices
             darwin.apple_sdk.frameworks.SystemConfiguration
           ];

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+# Present so that the default rustfmt configuration is used over any user specified configuration


### PR DESCRIPTION
This is a simple PR adding a couple methods for fs interactions that I was missing, namely a function to change the current working directory and a function mirroring file-name that returns the full path to the parent directory. I also attempted to add the correct docs for them, but it's possible I missed some places (and if there's automatic doc generation I didn't know how to run it).