### PR TITLE
Clean up flake.nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,7 +18,23 @@
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -1,23 +1,5 @@
 {
   "nodes": {
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1714906307,
@@ -36,23 +18,7 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,10 @@
   in {
     packages = eachSystem (system: {
       default = self.packages.${system}.steel;
-      steel = pkgsFor.${system}.callPackage ./nix/package.nix {};
+      steel = pkgsFor.${system}.callPackage ./nix/package.nix {
+        inherit (self.packages.${system}) steel;
+        inherit (pkgsFor.${system}.darwin.apple_sdk.frameworks) CoreServices SystemConfiguration;
+      };
     });
 
     formatter = eachSystem (system: pkgsFor.${system}.alejandra);
@@ -21,7 +24,9 @@
     defaultPackage = eachSystem (system: self.packages.${system}.default);
 
     devShells = eachSystem (system: {
-      default = pkgsFor.${system}.callPackage ./nix/package.nix {};
+      default = pkgsFor.${system}.callPackage ./nix/package.nix {
+        inherit (pkgsFor.${system}.darwin.apple_sdk.frameworks) Security;
+      };
     });
 
     apps = eachSystem (system: {

--- a/flake.nix
+++ b/flake.nix
@@ -14,8 +14,7 @@
     packages = eachSystem (system: {
       default = self.packages.${system}.steel;
       steel = pkgsFor.${system}.callPackage ./nix/package.nix {
-        inherit (self.packages.${system}) steel;
-        inherit (pkgsFor.${system}.darwin.apple_sdk.frameworks) CoreServices SystemConfiguration;
+        inherit (pkgsFor.${system}.darwin.apple_sdk.frameworks) Security;
       };
     });
 
@@ -24,8 +23,9 @@
     defaultPackage = eachSystem (system: self.packages.${system}.default);
 
     devShells = eachSystem (system: {
-      default = pkgsFor.${system}.callPackage ./nix/package.nix {
-        inherit (pkgsFor.${system}.darwin.apple_sdk.frameworks) Security;
+      default = pkgsFor.${system}.callPackage ./nix/shell.nix {
+        inherit (self.packages.${system}) steel;
+        inherit (pkgsFor.${system}.darwin.apple_sdk.frameworks) CoreServices SystemConfiguration;
       };
     });
 

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  stdenv,
+  darwin,
+  openssl,
+  pkg-config,
+  rustPlatform,
+}: let
+  manifest = lib.importTOML ../Cargo.toml;
+  fs = lib.fileset;
+in
+  rustPlatform.buildRustPackage {
+    pname = manifest.package.name;
+    version = manifest.workspace.package.version;
+    src = fs.toSource {
+      root = ../.;
+      fileset =
+        fs.intersection
+        (fs.gitTracked ../.)
+        (fs.fileFilter
+          (f:
+            f.name
+            == "Cargo.lock"
+            || f.hasExt "rkt"
+            || f.hasExt "rs"
+            || f.hasExt "scm"
+            || f.hasExt "toml")
+          ../.);
+    };
+    cargoLock = {
+      lockFile = ../Cargo.lock;
+    };
+    cargoBuildFlags = "-p cargo-steel-lib -p steel-interpreter";
+    buildInputs = [openssl] ++ lib.optionals stdenv.isDarwin [darwin.apple_sdk.frameworks.Security];
+    nativeBuildInputs = [
+      pkg-config
+    ];
+    # Test failing
+    doCheck = false;
+    postInstall = ''
+      substituteInPlace cogs/installer/download.scm --replace-warn "cargo-steel-lib" "$out/bin/cargo-steel-lib"
+      mkdir $out/lib
+      export STEEL_HOME="$out/lib"
+      pushd cogs
+      $out/bin/steel install.scm
+      popd
+      rm "$out/bin/cargo-steel-lib"
+    '';
+    meta = with lib; {
+      description = "An embedded scheme interpreter in Rust";
+      homepage = "https://github.com/mattwparas/steel";
+      license = with licenses; [asl20 mit];
+      mainProgram = "steel";
+    };
+  }

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -46,10 +46,10 @@ in
       popd
       rm "$out/bin/cargo-steel-lib"
     '';
-    meta = with lib; {
+    meta = {
       description = "An embedded scheme interpreter in Rust";
       homepage = "https://github.com/mattwparas/steel";
-      license = with licenses; [asl20 mit];
+      license = with lib.licenses; [asl20 mit];
       mainProgram = "steel";
     };
   }

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  darwin,
+  Security,
   openssl,
   pkg-config,
   rustPlatform,
@@ -31,7 +31,7 @@ in
       lockFile = ../Cargo.lock;
     };
     cargoBuildFlags = "-p cargo-steel-lib -p steel-interpreter";
-    buildInputs = [openssl] ++ lib.optionals stdenv.isDarwin [darwin.apple_sdk.frameworks.Security];
+    buildInputs = [openssl] ++ lib.optionals stdenv.isDarwin [Security];
     nativeBuildInputs = [
       pkg-config
     ];

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -12,6 +12,7 @@ in
   rustPlatform.buildRustPackage {
     pname = manifest.package.name;
     version = manifest.workspace.package.version;
+
     src = fs.toSource {
       root = ../.;
       fileset =
@@ -27,14 +28,17 @@ in
             || f.hasExt "toml")
           ../.);
     };
+
     cargoLock = {
       lockFile = ../Cargo.lock;
     };
     cargoBuildFlags = "-p cargo-steel-lib -p steel-interpreter";
+
     buildInputs = [openssl] ++ lib.optionals stdenv.isDarwin [Security];
     nativeBuildInputs = [
       pkg-config
     ];
+
     # Test failing
     doCheck = false;
     postInstall = ''
@@ -46,10 +50,12 @@ in
       popd
       rm "$out/bin/cargo-steel-lib"
     '';
+
     meta = {
       description = "An embedded scheme interpreter in Rust";
       homepage = "https://github.com/mattwparas/steel";
       license = with lib.licenses; [asl20 mit];
+      platforms = lib.platforms.unix;
       mainProgram = "steel";
     };
   }

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -5,11 +5,9 @@
   steel,
   cargo,
   rustc,
-  openssl,
   libiconv,
   CoreServices,
   SystemConfiguration,
-  pkg-config,
   rust-analyzer,
   rustfmt,
 }:
@@ -17,15 +15,17 @@ mkShell {
   shellHook = ''
     export STEEL_HOME="${steel}/lib/"
   '';
-  buildInputs =
-    [cargo rustc openssl libiconv]
+  packages =
+    [
+      cargo
+      rustc
+      rust-analyzer
+      rustfmt
+      libiconv
+    ]
     ++ lib.optionals stdenv.isDarwin [
       CoreServices
       SystemConfiguration
     ];
-  nativeBuildInputs = [
-    pkg-config
-    rust-analyzer
-    rustfmt
-  ];
+    inputsFrom = steel;
 }

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  stdenv,
+  mkShell,
+  steel,
+  cargo,
+  rustc,
+  openssl,
+  libiconv,
+  darwin,
+  pkg-config,
+  rust-analyzer,
+  rustfmt,
+}:
+mkShell {
+  shellHook = ''
+    export STEEL_HOME="${steel}/lib/"
+  '';
+  buildInputs =
+    [cargo rustc openssl libiconv]
+    ++ lib.optionals stdenv.isDarwin [
+      darwin.apple_sdk.frameworks.CoreServices
+      darwin.apple_sdk.frameworks.SystemConfiguration
+    ];
+  nativeBuildInputs = [
+    pkg-config
+    rust-analyzer
+    rustfmt
+  ];
+}

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -7,7 +7,8 @@
   rustc,
   openssl,
   libiconv,
-  darwin,
+  CoreServices,
+  SystemConfiguration,
   pkg-config,
   rust-analyzer,
   rustfmt,
@@ -19,8 +20,8 @@ mkShell {
   buildInputs =
     [cargo rustc openssl libiconv]
     ++ lib.optionals stdenv.isDarwin [
-      darwin.apple_sdk.frameworks.CoreServices
-      darwin.apple_sdk.frameworks.SystemConfiguration
+      CoreServices
+      SystemConfiguration
     ];
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
This PR gets rid of the flake's dependency on `flake-utils`, which is an  abstraction library which is definitely not necessary here. This might be nice to reduce the flake's complexity and make it more accessible for non-`flake-utils` users. 

Furthermore, I've moved the `devShell` and `steel package` parts of the flake into seperate files, which has several benefits:
- Upstreaming steel into `Nixpkgs` becomes much easier
- Common in many projects which have a `flake.nix` 
- Reduces the flake's complexity by a bit

I still have to test this to make sure everything behaves the same way as before, but it should be more or less correct.

This is a draft, so I'm open to any changes ofc  :)