### PR TITLE
analysis: don't do analysis for empty list

### DIFF
--- a/crates/steel-core/src/compiler/passes/analysis.rs
+++ b/crates/steel-core/src/compiler/passes/analysis.rs
@@ -1096,6 +1096,10 @@ impl<'a> VisitorMutUnitRef<'a> for AnalysisPass<'a> {
         // the function call.
         let stack_offset = self.stack_offset;
 
+        if l.is_empty() {
+            return;
+        }
+
         for expr in &l.args[1..] {
             self.escape_analysis = true;
 


### PR DESCRIPTION
This caused panic for the input `()`.

I was using `hx` with `steel-language-server`

```
2024-11-05T14:58:48.185 helix_lsp::transport [ERROR] steel-language-server err <- "thread 'main' panicked at crates/steel-core/src/compiler/passes/analysis.rs:1099:28:\n"
``` 