### PR TITLE
chore: fix low hanging lints

### DIFF
--- a/crates/cargo-steel-lib/src/lib.rs
+++ b/crates/cargo-steel-lib/src/lib.rs
@@ -27,10 +27,8 @@ pub fn steel_home() -> Option<PathBuf> {
                 // this is probably not the best place to do this. This almost
                 // assuredly could be lifted out of this check since failing here
                 // could cause some annoyance.
-                if !x.exists() {
-                    if let Err(_) = std::fs::create_dir(&x) {
-                        eprintln!("Unable to create steel home directory {:?}", x)
-                    }
+                if !x.exists() && std::fs::create_dir(&x).is_err() {
+                    eprintln!("Unable to create steel home directory {:?}", x)
                 }
 
                 x
@@ -94,13 +92,7 @@ pub fn run(args: Vec<String>, env_vars: Vec<(String, String)>) -> Result<(), Box
     });
 
     for last in artifacts {
-        if last
-            .target
-            .kind
-            .iter()
-            .find(|x| x.as_str() == "cdylib")
-            .is_some()
-        {
+        if last.target.kind.iter().any(|x| x.as_str() == "cdylib") {
             for file in last.filenames {
                 if matches!(file.extension(), Some("so") | Some("dylib") | Some("lib")) {
                     println!("Found a cdylib!");

--- a/crates/steel-core/benches/my_benchmark.rs
+++ b/crates/steel-core/benches/my_benchmark.rs
@@ -1,5 +1,3 @@
-#![allow(unused)]
-
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
 use steel::stdlib::PRELUDE;

--- a/crates/steel-core/src/compiler/code_gen.rs
+++ b/crates/steel-core/src/compiler/code_gen.rs
@@ -213,7 +213,6 @@ impl<'a> CodeGenerator<'a> {
         Some(())
     }
 
-    #[allow(unused)]
     fn specialize_call(&mut self, l: &List, op: OpCode) -> Option<()> {
         if l.args.len() != 3 {
             return None;

--- a/crates/steel-core/src/compiler/compiler.rs
+++ b/crates/steel-core/src/compiler/compiler.rs
@@ -349,7 +349,6 @@ pub struct SerializableCompiler {
 }
 
 impl SerializableCompiler {
-    #[allow(unused)]
     pub(crate) fn into_compiler(self) -> Compiler {
         let mut compiler = Compiler::default();
 
@@ -364,7 +363,6 @@ impl SerializableCompiler {
 }
 
 impl Compiler {
-    #[allow(unused)]
     pub(crate) fn into_serializable_compiler(self) -> Result<SerializableCompiler> {
         Ok(SerializableCompiler {
             symbol_map: self.symbol_map,

--- a/crates/steel-core/src/compiler/modules.rs
+++ b/crates/steel-core/src/compiler/modules.rs
@@ -234,7 +234,7 @@ impl ModuleManager {
         Ok(())
     }
 
-    // #[allow(unused)]
+    //
     pub(crate) fn compile_main(
         &mut self,
         global_macro_map: &mut FxHashMap<InternedString, SteelMacro>,
@@ -1678,7 +1678,7 @@ struct ModuleBuilder<'a> {
 
 impl<'a> ModuleBuilder<'a> {
     #[allow(clippy::too_many_arguments)]
-    #[allow(unused)]
+
     fn main(
         name: Option<PathBuf>,
         source_ast: Vec<ExprKind>,

--- a/crates/steel-core/src/compiler/program.rs
+++ b/crates/steel-core/src/compiler/program.rs
@@ -512,7 +512,6 @@ pub const fn sequence_to_opcode(pattern: &[(OpCode, usize)]) -> &'static [steel_
     }
 }
 
-#[allow(unused)]
 pub fn tile_super_instructions(instructions: &mut [Instruction]) {
     #[cfg(feature = "dynamic")]
     {
@@ -1189,7 +1188,7 @@ fn extract_spans(
 
 // A program stripped of its debug symbols, but only constructable by running a pass
 // over it with the symbol map to intern all of the symbols in the order they occurred
-#[allow(unused)]
+
 #[derive(Clone)]
 pub struct Executable {
     pub(crate) name: Shared<String>,

--- a/crates/steel-core/src/env.rs
+++ b/crates/steel-core/src/env.rs
@@ -5,7 +5,6 @@ use std::sync::Arc;
 
 use crate::rvals::{Result, SteelVal};
 
-#[allow(unused)]
 #[derive(Debug)]
 pub struct Env {
     #[cfg(not(feature = "sync"))]

--- a/crates/steel-core/src/gc.rs
+++ b/crates/steel-core/src/gc.rs
@@ -635,12 +635,8 @@ pub mod unsafe_erased_pointers {
     */
 
     use std::cell::Cell;
-    use std::rc::{Rc, Weak};
-    use std::{any::Any, cell::RefCell, marker::PhantomData};
-
-    use crate::steel_vm::engine::EngineId;
-    use once_cell::sync::Lazy;
-    use std::collections::HashMap;
+    use std::rc::Rc;
+    use std::{any::Any, marker::PhantomData};
 
     use crate::rvals::cycles::IterativeDropHandler;
     use crate::rvals::{AsRefSteelValFromRef, MaybeSendSyncStatic};

--- a/crates/steel-core/src/gc.rs
+++ b/crates/steel-core/src/gc.rs
@@ -627,7 +627,7 @@ pub mod unsafe_roots {
 }
 
 // #[cfg(feature = "unsafe-internals")]
-#[allow(unused)]
+
 pub mod unsafe_erased_pointers {
     /*
     Warning - here be dragons. Definitely a lot of unsafe things here, and when used incorrectly

--- a/crates/steel-core/src/jit/code_gen.rs
+++ b/crates/steel-core/src/jit/code_gen.rs
@@ -1,4 +1,4 @@
-#![allow(unused)]
+
 
 use crate::gc::Gc;
 use crate::jit::ir::*;

--- a/crates/steel-core/src/jit/lower.rs
+++ b/crates/steel-core/src/jit/lower.rs
@@ -1,4 +1,4 @@
-#![allow(unused)]
+
 
 use crate::parser::ast::ExprKind;
 use crate::parser::tokens::TokenType;

--- a/crates/steel-core/src/jit/mod.rs
+++ b/crates/steel-core/src/jit/mod.rs
@@ -1,4 +1,4 @@
-#![allow(unused)]
+
 
 pub mod code_gen;
 pub mod ir;

--- a/crates/steel-core/src/steel_vm/contract_checker.rs
+++ b/crates/steel-core/src/steel_vm/contract_checker.rs
@@ -1,6 +1,6 @@
 /*
 
-#![allow(unused)]
+
 use std::collections::{BTreeSet, HashMap};
 
 use quickscope::ScopeMap;

--- a/crates/steel-core/src/steel_vm/engine.rs
+++ b/crates/steel-core/src/steel_vm/engine.rs
@@ -1,5 +1,3 @@
-#![allow(unused)]
-
 use super::{
     builtin::{BuiltInModule, FunctionSignatureMetadata},
     primitives::{register_builtin_modules, CONSTANTS},

--- a/crates/steel-core/src/steel_vm/meta.rs
+++ b/crates/steel-core/src/steel_vm/meta.rs
@@ -1,20 +1,16 @@
 // pub type BuiltInSignature = fn(Vec<SteelVal>, &mut dyn VmContext) -> Result<SteelVal>;`
 
 use std::borrow::Cow;
-use std::{cell::RefCell, convert::TryFrom, io::Write, rc::Rc};
+use std::{convert::TryFrom, io::Write};
 
 use crate::gc::shared::ShareableMut;
 use crate::parser::tryfrom_visitor::TryFromExprKindForSteelVal;
 // use im_lists::list::List;
 use crate::values::lists::List;
 
-use crate::values::port::SteelPortRepr;
 use crate::values::structs::SteelResult;
 use crate::{
-    parser::ast::ExprKind,
-    rvals::Custom,
-    values::port::{SteelPort, CAPTURED_OUTPUT_PORT, DEFAULT_OUTPUT_PORT},
-    SteelErr, SteelVal,
+    parser::ast::ExprKind, rvals::Custom, values::port::CAPTURED_OUTPUT_PORT, SteelErr, SteelVal,
 };
 use crate::{parser::expander::LocalMacroManager, rvals::Result};
 use crate::{parser::parser::ParseError, steel_vm::engine::Engine};

--- a/crates/steel-core/src/steel_vm/meta.rs
+++ b/crates/steel-core/src/steel_vm/meta.rs
@@ -1,5 +1,3 @@
-#![allow(unused)]
-
 // pub type BuiltInSignature = fn(Vec<SteelVal>, &mut dyn VmContext) -> Result<SteelVal>;`
 
 use std::borrow::Cow;

--- a/crates/steel-core/src/steel_vm/register_fn.rs
+++ b/crates/steel-core/src/steel_vm/register_fn.rs
@@ -1,10 +1,7 @@
-use std::{cell::RefCell, future::Future, marker::PhantomData, rc::Rc, sync::Arc};
+use std::{future::Future, marker::PhantomData, rc::Rc, sync::Arc};
 
-use super::{
-    builtin::{Arity, FunctionSignatureMetadata},
-    engine::Engine,
-};
-use crate::{gc::Gc, rvals::MaybeSendSyncStatic, values::lists::List};
+use super::engine::Engine;
+use crate::{gc::Gc, rvals::MaybeSendSyncStatic};
 use crate::{
     gc::{
         shared::MutContainer,
@@ -348,7 +345,7 @@ impl<
                 e.prepend_message(&format!("{}:", name));
                 e
             })?;
-            let mut area = <AREA>::from_steelval(&args[1]).map_err(|mut e| {
+            let area = <AREA>::from_steelval(&args[1]).map_err(|mut e| {
                 e.prepend_message(&format!("{}:", name));
                 e
             })?;
@@ -396,7 +393,7 @@ impl<
                 e.prepend_message(&format!("{}:", name));
                 e
             })?;
-            let mut area = <AREA>::from_steelval(&args[1]).map_err(|mut e| {
+            let area = <AREA>::from_steelval(&args[1]).map_err(|mut e| {
                 e.prepend_message(&format!("{}:", name));
                 e
             })?;
@@ -439,13 +436,13 @@ impl<
                 stop!(ArityMismatch => format!("{} expected {} argument, got {}", name, 3, args.len()));
             }
 
-            let mut nursery = <AREA as AsRefSteelVal>::Nursery::default();
+            let nursery = <AREA as AsRefSteelVal>::Nursery::default();
 
             let mut input = <SELF>::as_mut_ref(&args[0]).map_err(|mut e| {
                 e.prepend_message(&format!("{}:", name));
                 e
             })?;
-            let mut area = <AREA>::as_ref(&args[1]).map_err(|mut e| {
+            let area = <AREA>::as_ref(&args[1]).map_err(|mut e| {
                 e.prepend_message(&format!("{}:", name));
                 e
             })?;
@@ -484,17 +481,17 @@ impl<
                 stop!(ArityMismatch => format!("{} expected {} argument, got {}", name, 3, args.len()));
             }
 
-            let mut nursery = <SELF as AsRefSteelVal>::Nursery::default();
+            let nursery = <SELF as AsRefSteelVal>::Nursery::default();
 
-            let mut input = <SELF>::as_ref(&args[0]).map_err(|mut e| {
+            let input = <SELF>::as_ref(&args[0]).map_err(|mut e| {
                 e.prepend_message(&format!("{}:", name));
                 e
             })?;
-            let mut area = <AREA>::from_steelval(&args[1]).map_err(|mut e| {
+            let area = <AREA>::from_steelval(&args[1]).map_err(|mut e| {
                 e.prepend_message(&format!("{}:", name));
                 e
             })?;
-            let mut ctx = <CTX>::as_ref_from_ref(&args[2]).map_err(|mut e| {
+            let ctx = <CTX>::as_ref_from_ref(&args[2]).map_err(|mut e| {
                 e.prepend_message(&format!("{}:", name));
                 e
             })?;
@@ -776,7 +773,7 @@ impl<
             }
 
             // If this value is
-            let mut input = <SELF>::as_mut_ref_from_ref(&args[0]).map_err(|mut e| {
+            let input = <SELF>::as_mut_ref_from_ref(&args[0]).map_err(|mut e| {
                 e.prepend_message(&format!("{}:", name));
                 e
             })?;
@@ -809,7 +806,7 @@ impl<
             // Mark as borrowed now
             borrow_flag.set(true);
 
-            let mut borrowed = BorrowedObject::new(weak_ptr).with_parent_flag(borrow_flag);
+            let borrowed = BorrowedObject::new(weak_ptr).with_parent_flag(borrow_flag);
 
             let extended = unsafe {
                 std::mem::transmute::<BorrowedObject<RET>, BorrowedObject<STATICRET>>(borrowed)
@@ -860,7 +857,7 @@ impl<
             }
 
             // If this value is
-            let mut input = <SELF>::as_mut_ref_from_ref(&args[0]).map_err(|mut e| {
+            let input = <SELF>::as_mut_ref_from_ref(&args[0]).map_err(|mut e| {
                 e.prepend_message(&format!("{}:", name));
                 e
             })?;
@@ -938,7 +935,7 @@ impl<
             }
 
             // If this value is
-            let mut input = <SELF>::as_mut_ref_from_ref(&args[0]).map_err(|mut e| {
+            let input = <SELF>::as_mut_ref_from_ref(&args[0]).map_err(|mut e| {
                 e.prepend_message(&format!("{}:", name));
                 e
             })?;
@@ -1020,7 +1017,7 @@ impl<
             }
 
             // If this value is
-            let mut input = <SELF>::as_ref_from_ref(&args[0]).map_err(|mut e| {
+            let input = <SELF>::as_ref_from_ref(&args[0]).map_err(|mut e| {
                 e.prepend_message(&format!("{}:", name));
                 e
             })?;
@@ -1094,7 +1091,7 @@ impl<
             }
 
             // If this value is
-            let mut input = <SELF>::as_ref_from_ref(&args[0]).map_err(|mut e| {
+            let input = <SELF>::as_ref_from_ref(&args[0]).map_err(|mut e| {
                 e.prepend_message(&format!("{}:", name));
                 e
             })?;
@@ -1159,13 +1156,13 @@ impl<
                 stop!(ArityMismatch => format!("{} expected {} argument, got {}", name, 3, args.len()));
             }
 
-            let mut nursery = <AREA as AsRefSteelVal>::Nursery::default();
+            let nursery = <AREA as AsRefSteelVal>::Nursery::default();
 
             let mut input = <SELF>::as_mut_ref(&args[0]).map_err(|mut e| {
                 e.prepend_message(&format!("{}:", name));
                 e
             })?;
-            let mut area = <AREA>::as_ref(&args[1]).map_err(|mut e| {
+            let area = <AREA>::as_ref(&args[1]).map_err(|mut e| {
                 e.prepend_message(&format!("{}:", name));
                 e
             })?;
@@ -1204,17 +1201,17 @@ impl<
                 stop!(ArityMismatch => format!("{} expected {} argument, got {}", name, 3, args.len()));
             }
 
-            let mut nursery = <SELF as AsRefSteelVal>::Nursery::default();
+            let nursery = <SELF as AsRefSteelVal>::Nursery::default();
 
-            let mut input = <SELF>::as_ref(&args[0]).map_err(|mut e| {
+            let input = <SELF>::as_ref(&args[0]).map_err(|mut e| {
                 e.prepend_message(&format!("{}:", name));
                 e
             })?;
-            let mut area = <AREA>::from_steelval(&args[1]).map_err(|mut e| {
+            let area = <AREA>::from_steelval(&args[1]).map_err(|mut e| {
                 e.prepend_message(&format!("{}:", name));
                 e
             })?;
-            let mut ctx = <CTX>::as_ref_from_ref(&args[2]).map_err(|mut e| {
+            let ctx = <CTX>::as_ref_from_ref(&args[2]).map_err(|mut e| {
                 e.prepend_message(&format!("{}:", name));
                 e
             })?;
@@ -1350,7 +1347,7 @@ impl<
             }
 
             // If this value is
-            let mut input = <SELF>::as_mut_ref_from_ref(&args[0]).map_err(|mut e| {
+            let input = <SELF>::as_mut_ref_from_ref(&args[0]).map_err(|mut e| {
                 e.prepend_message(&format!("{}:", name));
                 e
             })?;
@@ -1434,7 +1431,7 @@ impl<
             }
 
             // If this value is
-            let mut input = <SELF>::as_mut_ref_from_ref(&args[0]).map_err(|mut e| {
+            let input = <SELF>::as_mut_ref_from_ref(&args[0]).map_err(|mut e| {
                 e.prepend_message(&format!("{}:", name));
                 e
             })?;
@@ -1516,7 +1513,7 @@ impl<
             }
 
             // If this value is
-            let mut input = <SELF>::as_mut_ref_from_ref(&args[0]).map_err(|mut e| {
+            let input = <SELF>::as_mut_ref_from_ref(&args[0]).map_err(|mut e| {
                 e.prepend_message(&format!("{}:", name));
                 e
             })?;
@@ -1699,7 +1696,7 @@ impl<RET: IntoSteelVal, SELF: AsRefSteelVal, FN: Fn(&SELF) -> RET + SendSyncStat
                 stop!(ArityMismatch => format!("{} expected {} argument, got {}", name, 0, args.len()));
             }
 
-            let mut nursery = <SELF::Nursery>::default();
+            let nursery = <SELF::Nursery>::default();
 
             let input = <SELF>::as_ref(&args[0]).map_err(|mut e| {
                 e.prepend_message(&format!("{}:", name));
@@ -1730,7 +1727,7 @@ impl<RET: IntoSteelVal, SELF: AsRefSteelVal, FN: Fn(&SELF) -> RET + SendSyncStat
                 stop!(ArityMismatch => format!("{} expected {} argument, got {}", name, 1, args.len()));
             }
 
-            let mut nursery = <SELF::Nursery>::default();
+            let nursery = <SELF::Nursery>::default();
 
             let input = <SELF>::as_ref(&args[0]).map_err(|mut e| {
                 e.prepend_message(&format!("{}:", name));
@@ -1949,14 +1946,14 @@ impl<
                 stop!(ArityMismatch => format!("{} expected {} argument, got {}", name, 2, args.len()));
             }
 
-            let mut nursery = <A::Nursery>::default();
+            let nursery = <A::Nursery>::default();
 
             let one = A::as_ref(&args[0]).map_err(|mut e| {
                 e.prepend_message(&format!("{}:", name));
                 e
             })?;
 
-            let mut nursery = <B::Nursery>::default();
+            let nursery = <B::Nursery>::default();
 
             let two = B::as_ref(&args[1]).map_err(|mut e| {
                 e.prepend_message(&format!("{}:", name));
@@ -1992,7 +1989,7 @@ impl<
                 stop!(ArityMismatch => format!("{} expected {} argument, got {}", name, 2, args.len()));
             }
 
-            let mut nursery = <B::Nursery>::default();
+            let nursery = <B::Nursery>::default();
 
             let input = B::as_ref(&args[1])?;
 
@@ -2145,7 +2142,7 @@ macro_rules! impl_register_fn_self {
                         stop!(ArityMismatch => format!("{} expected {} argument, got {}", name, $arg_count, args.len()));
                     }
 
-                    let mut nursery = <SELF::Nursery>::default();
+                    let nursery = <SELF::Nursery>::default();
 
                     let input = <SELF>::as_ref(&args[0]).map_err(|mut e| {
                 e.prepend_message(&format!("{}:", name));

--- a/crates/steel-core/src/steel_vm/register_fn.rs
+++ b/crates/steel-core/src/steel_vm/register_fn.rs
@@ -1,5 +1,3 @@
-#![allow(unused)]
-
 use std::{cell::RefCell, future::Future, marker::PhantomData, rc::Rc, sync::Arc};
 
 use super::{

--- a/crates/steel-core/src/steel_vm/vm.rs
+++ b/crates/steel-core/src/steel_vm/vm.rs
@@ -1,5 +1,3 @@
-#![allow(unused)]
-
 use crate::compiler::code_gen::fresh_function_id;
 use crate::compiler::compiler::Compiler;
 use crate::core::instructions::pretty_print_dense_instructions;
@@ -6677,7 +6675,6 @@ fn set_alloc_handler(ctx: &mut VmCore<'_>) -> Result<()> {
     */
 }
 
-#[allow(unused)]
 mod handlers {
 
     use super::*;

--- a/crates/steel-core/src/steel_vm/vm.rs
+++ b/crates/steel-core/src/steel_vm/vm.rs
@@ -361,10 +361,6 @@ pub struct SafepointablePointer<T> {
 }
 
 impl<T> SafepointablePointer<T> {
-    pub unsafe fn get_mut(&self) -> &mut T {
-        &mut *self.value.get()
-    }
-
     pub unsafe fn get_safepoint_safe(&self) -> Option<&T> {
         if self
             .within_safepoint

--- a/crates/steel-core/src/steel_vm/vm/threads.rs
+++ b/crates/steel-core/src/steel_vm/vm/threads.rs
@@ -159,7 +159,7 @@ pub fn closure_into_serializable(
     serializer: &mut std::collections::HashMap<usize, SerializableSteelVal>,
     visited: &mut std::collections::HashSet<usize>,
 ) -> Result<SerializedLambda> {
-    if let Some(mut prototype) = CACHED_CLOSURES.with(|x| x.borrow().get(&c.id).cloned()) {
+    if let Some(prototype) = CACHED_CLOSURES.with(|x| x.borrow().get(&c.id).cloned()) {
         let mut prototype = SerializedLambda {
             id: prototype.id,
             body_exp: prototype.body_exp,
@@ -177,7 +177,7 @@ pub fn closure_into_serializable(
 
         Ok(prototype)
     } else {
-        let mut prototype = SerializedLambdaPrototype {
+        let prototype = SerializedLambdaPrototype {
             id: c.id,
 
             #[cfg(not(feature = "dynamic"))]
@@ -384,7 +384,7 @@ fn spawn_thread_result(ctx: &mut VmCore, args: &[SteelVal]) -> Result<SteelVal> 
     // TODO: Spawn a bunch of threads at the start to handle requests. That way we don't need to do this
     // the whole time they're in there.
     let handle = std::thread::spawn(move || {
-        let mut heap = time!("Heap Creation", Arc::new(Mutex::new(Heap::new())));
+        let heap = time!("Heap Creation", Arc::new(Mutex::new(Heap::new())));
 
         // Move across threads?
         let mut mapping = initial_map
@@ -593,7 +593,7 @@ impl Channels {
 pub fn select(values: &[SteelVal]) -> Result<SteelVal> {
     let mut selector = crossbeam::channel::Select::new();
 
-    let mut borrows = values
+    let borrows = values
         .iter()
         .map(|x| SteelReceiver::as_ref(x))
         .collect::<Result<smallvec::SmallVec<[_; 8]>>>()?;

--- a/crates/steel-core/src/values/functions.rs
+++ b/crates/steel-core/src/values/functions.rs
@@ -1,5 +1,3 @@
-#![allow(unused)]
-
 use std::{
     cell::{Cell, RefCell},
     collections::HashMap,

--- a/crates/steel-core/src/values/functions.rs
+++ b/crates/steel-core/src/values/functions.rs
@@ -1,37 +1,20 @@
-use std::{
-    cell::{Cell, RefCell},
-    collections::HashMap,
-    convert::TryFrom,
-    hash::Hasher,
-    sync::Arc,
-};
-
-use fxhash::FxHashSet;
+use std::{collections::HashMap, hash::Hasher, sync::Arc};
 
 use crate::{
-    core::{instructions::DenseInstruction, opcode::OpCode},
+    core::instructions::DenseInstruction,
     gc::{
         shared::{MutContainer, ShareableMut},
         Gc, Shared, SharedMut,
     },
-    parser::{parser::SyntaxObjectId, span::Span},
+    parser::parser::SyntaxObjectId,
     rvals::{
-        from_serializable_value, into_serializable_value, AsRefSteelVal, Custom, FunctionSignature,
-        HeapSerializer, IntoSteelVal, MutFunctionSignature, SerializableSteelVal, SteelString,
+        from_serializable_value, AsRefSteelVal, Custom, HeapSerializer, IntoSteelVal,
+        SerializableSteelVal, SteelString,
     },
-    steel_vm::{
-        register_fn::SendSyncStatic,
-        vm::{BlockMetadata, BlockPattern, BuiltInSignature},
-    },
-    // values::contracts::ContractedFunction,
-    SteelErr,
     SteelVal,
 };
 
-use super::{
-    closed::{Heap, HeapRef},
-    structs::UserDefinedStruct,
-};
+use super::structs::UserDefinedStruct;
 
 // pub(crate) enum Function {
 //     BoxedFunction(BoxedFunctionSignature),

--- a/crates/steel-core/src/values/json_vals.rs
+++ b/crates/steel-core/src/values/json_vals.rs
@@ -48,7 +48,7 @@ pub fn serialize_val_to_string(value: SteelVal) -> Result<SteelVal> {
 }
 
 // required to parse each string
-#[allow(unused)]
+
 fn unescape(s: &str) -> String {
     let mut result = String::with_capacity(s.len());
     let mut chars = s.chars();

--- a/crates/steel-core/src/values/recycler.rs
+++ b/crates/steel-core/src/values/recycler.rs
@@ -69,7 +69,6 @@ impl<T: Recyclable + std::hash::Hash + Default> std::hash::Hash for Recycle<T> {
 
 static RECYCLE_LIMIT: AtomicUsize = AtomicUsize::new(128);
 
-#[allow(unused)]
 fn set_recycle_limit(value: usize) {
     RECYCLE_LIMIT.store(value, Ordering::Relaxed);
 }

--- a/crates/steel-core/src/values/structs.rs
+++ b/crates/steel-core/src/values/structs.rs
@@ -171,13 +171,6 @@ impl UserDefinedStruct {
     }
 }
 
-// TODO: This could blow the stack for big trees...
-impl PartialEq for UserDefinedStruct {
-    fn eq(&self, other: &Self) -> bool {
-        self.type_descriptor == other.type_descriptor && self.fields.deref() == other.fields.deref()
-    }
-}
-
 impl std::fmt::Display for UserDefinedStruct {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if self

--- a/crates/steel-core/src/values/structs.rs
+++ b/crates/steel-core/src/values/structs.rs
@@ -1,4 +1,3 @@
-#![allow(unused)]
 #![allow(clippy::type_complexity)]
 
 use crate::steel_vm::primitives::{steel_unbox_mutable, unbox_mutable};

--- a/crates/steel-core/src/values/structs.rs
+++ b/crates/steel-core/src/values/structs.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::type_complexity)]
 
-use crate::steel_vm::primitives::{steel_unbox_mutable, unbox_mutable};
+use crate::steel_vm::primitives::steel_unbox_mutable;
 use crate::values::HashMap;
 use once_cell::sync::Lazy;
 use parking_lot::RwLock;
@@ -11,29 +11,22 @@ use crate::parser::interner::InternedString;
 use crate::rerrs::ErrorKind;
 use crate::rvals::{
     from_serializable_value, into_serializable_value, Custom, HeapSerializer, SerializableSteelVal,
-    SerializedHeapRef, SteelHashMap,
 };
 use crate::rvals::{FromSteelVal, IntoSteelVal};
 use crate::steel_vm::register_fn::RegisterFn;
 use crate::throw;
 use crate::{
     gc::Gc,
-    rvals::{AsRefSteelVal, SRef, SteelString},
+    rvals::{AsRefSteelVal, SteelString},
 };
 use crate::{
     rvals::{Result, SteelVal},
     SteelErr,
 };
 use crate::{steel_vm::builtin::BuiltInModule, stop};
-use std::collections::VecDeque;
-use std::ops::Deref;
 use std::sync::Arc;
-use std::{
-    cell::{Ref, RefCell},
-    rc::Rc,
-};
+use std::{cell::RefCell, rc::Rc};
 
-use super::closed::Heap;
 use super::functions::BoxedDynFunction;
 use super::lists::List;
 use super::recycler::Recycle;
@@ -484,7 +477,7 @@ impl UserDefinedStruct {
 // This in practice should yield some nice performance
 pub fn struct_update_primitive(args: &mut [SteelVal]) -> Result<SteelVal> {
     if let Some((SteelVal::CustomStruct(s), fields)) = args.split_first_mut() {
-        let mut fields = fields.iter_mut();
+        let fields = fields.iter_mut();
 
         let struct_fields = s.type_descriptor.fields();
 

--- a/crates/steel-derive/src/lib.rs
+++ b/crates/steel-derive/src/lib.rs
@@ -149,7 +149,7 @@ fn derive_steel_impl(input: DeriveInput, prefix: proc_macro2::TokenStream) -> To
                 let identifier = &variant.ident;
 
                 for attr in &variant.attrs {
-                    if !filter_out_ignored_attr(&attr) {
+                    if !filter_out_ignored_attr(attr) {
                         continue 'variant;
                     }
                 }
@@ -540,9 +540,9 @@ fn parse_doc_comment(input: ItemFn) -> Option<proc_macro2::TokenStream> {
         args.push(expr);
     }
 
-    return Some(quote! {
+    Some(quote! {
         concat![#(#args),*]
-    });
+    })
 }
 
 #[proc_macro_attribute]

--- a/crates/steel-doc/src/lib.rs
+++ b/crates/steel-doc/src/lib.rs
@@ -1,4 +1,4 @@
-use std::{env::current_dir, error::Error, io::BufWriter, path::PathBuf};
+use std::{env::current_dir, error::Error, path::PathBuf};
 
 use steel::compiler::modules::MANGLER_PREFIX;
 use steel::steel_vm::engine::Engine;

--- a/crates/steel-doc/src/lib.rs
+++ b/crates/steel-doc/src/lib.rs
@@ -1,5 +1,3 @@
-#![allow(unused)]
-
 use std::{env::current_dir, error::Error, io::BufWriter, path::PathBuf};
 
 use steel::compiler::modules::MANGLER_PREFIX;

--- a/crates/steel-doc/src/main.rs
+++ b/crates/steel-doc/src/main.rs
@@ -35,7 +35,7 @@ fn main() {
 
         // module.documentation().definitions().get()
 
-        if let Some(module_doc) = module.documentation().get(&module_name) {
+        if let Some(module_doc) = module.documentation().get(module_name) {
             if let steel::steel_vm::builtin::Documentation::Markdown(m) = module_doc {
                 format_markdown_doc(&mut module_file, &m.0);
             }
@@ -60,14 +60,11 @@ fn main() {
 
                 found_definitions.insert(name.to_string());
 
-                match value {
-                    steel::steel_vm::builtin::Documentation::Markdown(m) => {
-                        let escaped = name.replace("*", "\\*");
-                        writeln!(&mut module_file, "### **{}**", escaped).unwrap();
+                if let steel::steel_vm::builtin::Documentation::Markdown(m) = value {
+                    let escaped = name.replace("*", "\\*");
+                    writeln!(&mut module_file, "### **{}**", escaped).unwrap();
 
-                        format_markdown_doc(&mut module_file, &m.0);
-                    }
-                    _ => {}
+                    format_markdown_doc(&mut module_file, &m.0);
                 }
             }
         }

--- a/crates/steel-gen/src/lib.rs
+++ b/crates/steel-gen/src/lib.rs
@@ -1,5 +1,4 @@
 // TODO: Create stack to ssa representation of the op codes, via macros
-#![allow(unused)]
 
 pub mod opcode;
 pub mod permutations;

--- a/crates/steel-gen/src/lib.rs
+++ b/crates/steel-gen/src/lib.rs
@@ -330,7 +330,7 @@ impl StackToSSAConverter {
                         max_local_offset_read = max_local_offset_read.max(0);
                     } else {
                         let local = self.push();
-                        let var = self.stack.get(0).unwrap();
+                        let var = self.stack.first().unwrap();
 
                         if &local == var {
                             lines.line(format!(
@@ -362,7 +362,7 @@ impl StackToSSAConverter {
                         if &local == var {
                             // let local = self.pop();
 
-                            let var = self.stack.get(0).unwrap();
+                            let var = self.stack.first().unwrap();
 
                             lines.line(format!("let {local} = {var}.clone();"));
                             lines.line("ctx.ip += 1;")
@@ -454,7 +454,7 @@ impl StackToSSAConverter {
                         max_local_offset_read = max_local_offset_read.max(0);
                     } else {
                         let local = self.push();
-                        let var = self.stack.get(0).unwrap();
+                        let var = self.stack.first().unwrap();
                         lines.line(format!("let {local} = {var};"));
                     }
                 }
@@ -806,7 +806,7 @@ impl<'a> Call<'a> {
     }
 }
 
-impl<'a> std::fmt::Display for Call<'a> {
+impl std::fmt::Display for Call<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.name)?;
         write!(f, "(")?;
@@ -951,7 +951,7 @@ pub fn generate_opcode_map() -> String {
 
     for pattern in patterns {
         let original_pattern = pattern;
-        let pattern = Pattern::from_opcodes(&pattern);
+        let pattern = Pattern::from_opcodes(pattern);
 
         if pattern.is_empty() {
             dbg!("Pattern produced empty result: {:?}", original_pattern);
@@ -1058,8 +1058,6 @@ fn test() {
     //     Pattern::Single(OpCode::IF),
     // ];
 
-    use OpCode::*;
-
     let op_codes = vec![
         (OpCode::BEGINSCOPE, 0),
         (OpCode::READLOCAL0, 0),
@@ -1093,8 +1091,6 @@ fn test() {
 
 #[test]
 fn test_generation() {
-    use OpCode::*;
-
     // TODO: Come up with better way for this to make it in
     // let patterns: &'static [&'static [(OpCode, usize)]] = &[&[
     //     (MOVEREADLOCAL0, 0),

--- a/crates/steel-gen/src/opcode.rs
+++ b/crates/steel-gen/src/opcode.rs
@@ -200,7 +200,7 @@ impl OpCode {
     pub fn is_super_instruction(&self) -> bool {
         // TODO: Check where super instructions start!
 
-        return *self as u32 > Self::LTEIMMEDIATEIF as u32;
+        *self as u32 > Self::LTEIMMEDIATEIF as u32
     }
 
     /// Statically create the mapping we need for super instruction. Also, as part of the op code map generating,

--- a/crates/steel-gen/src/permutations.rs
+++ b/crates/steel-gen/src/permutations.rs
@@ -233,7 +233,7 @@ fn code_gen_permutation(values: &[ValueKind], id: usize, row: usize) -> String {
 
     let mut scope = codegen::Scope::new();
 
-    let mut marker = scope.new_struct(&format!("Marker{row}{id}"));
+    let marker = scope.new_struct(&format!("Marker{row}{id}"));
 
     marker.generic("ARGS");
     marker.tuple_field("PhantomData<ARGS>");

--- a/crates/steel-language-server/src/backend.rs
+++ b/crates/steel-language-server/src/backend.rs
@@ -1,5 +1,3 @@
-#![allow(unused)]
-
 use std::{
     cell::RefCell,
     collections::{HashMap, HashSet},

--- a/crates/steel-language-server/src/diagnostics.rs
+++ b/crates/steel-language-server/src/diagnostics.rs
@@ -1,5 +1,3 @@
-#![allow(unused)]
-
 use std::{
     collections::{BTreeSet, HashMap},
     iter::FlatMap,

--- a/crates/steel-language-server/src/main.rs
+++ b/crates/steel-language-server/src/main.rs
@@ -47,7 +47,7 @@ async fn main() {
     let home_directory = lsp_home();
 
     ENGINE.write().unwrap().register_module_resolver(
-        ExternalModuleResolver::new(&mut resolver_engine, PathBuf::from(home_directory)).unwrap(),
+        ExternalModuleResolver::new(&mut resolver_engine, home_directory).unwrap(),
     );
 
     {

--- a/crates/steel-parser/src/ast.rs
+++ b/crates/steel-parser/src/ast.rs
@@ -1282,7 +1282,7 @@ impl List {
     }
 
     pub fn is_anonymous_function_call(&self) -> bool {
-        matches!(self.args.get(0), Some(ExprKind::LambdaFunction(_)))
+        matches!(self.args.first(), Some(ExprKind::LambdaFunction(_)))
     }
 
     pub fn is_a_builtin_expr(&self) -> bool {
@@ -1298,7 +1298,7 @@ impl List {
     }
 
     pub fn first_func(&self) -> Option<&LambdaFunction> {
-        if let Some(ExprKind::LambdaFunction(l)) = self.args.get(0) {
+        if let Some(ExprKind::LambdaFunction(l)) = self.args.first() {
             Some(l)
         } else {
             None

--- a/crates/steel-parser/src/parser.rs
+++ b/crates/steel-parser/src/parser.rs
@@ -308,7 +308,7 @@ enum ParsingContext {
     UnquoteSplicingTick(usize),
 }
 
-impl<'a> Parser<'a> {
+impl Parser<'_> {
     pub fn parse(expr: &str) -> Result<Vec<ExprKind>> {
         Parser::new(expr, SourceId::none()).collect()
     }
@@ -1005,12 +1005,12 @@ impl<'a> Parser<'a> {
                                     | Some(ParsingContext::QuasiquoteTick(_)) => {
                                         // | Some(ParsingContext::Quote(d)) && d > 0 => {
 
-                                        return Ok(current_frame.to_expr(close)?);
+                                        return current_frame.to_expr(close);
                                     }
                                     Some(ParsingContext::Quote(x)) if *x > 0 => {
                                         self.context.pop();
 
-                                        return Ok(current_frame.to_expr(close)?);
+                                        return current_frame.to_expr(close);
                                     }
                                     Some(ParsingContext::Quote(0)) => {
                                         self.context.pop();
@@ -1037,7 +1037,7 @@ impl<'a> Parser<'a> {
 
                                             // println!("Should still be quoted here");
 
-                                            return Ok(current_frame.to_expr(close)?);
+                                            return current_frame.to_expr(close);
                                         }
 
                                         return self.maybe_lower_frame(current_frame, close);
@@ -1124,7 +1124,7 @@ fn wrap_in_doc_function(expr: ExprKind, comment: String) -> ExprKind {
     ]))
 }
 
-impl<'a> Parser<'a> {
+impl Parser<'_> {
     fn get_next_and_maybe_wrap_in_doc(&mut self) -> Option<Result<ExprKind>> {
         let mut next;
 
@@ -1354,7 +1354,7 @@ impl<'a> Parser<'a> {
     }
 }
 
-impl<'a> Iterator for Parser<'a> {
+impl Iterator for Parser<'_> {
     type Item = Result<ExprKind>;
 
     // TODO -> put the
@@ -1796,7 +1796,8 @@ impl Frame {
             }
         }
 
-        Ok(self.exprs.push(expr))
+        self.exprs.push(expr);
+        Ok(())
     }
 
     fn improper(&self) -> Result<bool> {
@@ -1805,11 +1806,11 @@ impl Frame {
             Some((idx, span)) => {
                 debug_assert_eq!(idx, self.exprs.len());
 
-                return Err(ParseError::SyntaxError(
+                Err(ParseError::SyntaxError(
                     "Improper list must have a single cdr".into(),
                     span,
                     None,
-                ));
+                ))
             }
             None => Ok(false),
         }

--- a/crates/steel-parser/src/span.rs
+++ b/crates/steel-parser/src/span.rs
@@ -63,7 +63,7 @@ impl Span {
     }
 
     pub fn coalesce_span(spans: &[Span]) -> Span {
-        let span = spans.get(0);
+        let span = spans.first();
         if let Some(span) = span {
             let mut span = *span;
             for s in spans {

--- a/crates/steel-parser/src/tokens.rs
+++ b/crates/steel-parser/src/tokens.rs
@@ -227,7 +227,7 @@ impl RealLiteral {
 
 impl From<RealLiteral> for NumberLiteral {
     fn from(value: RealLiteral) -> Self {
-        NumberLiteral::Real(value).into()
+        NumberLiteral::Real(value)
     }
 }
 

--- a/crates/steel-repl/src/highlight.rs
+++ b/crates/steel-repl/src/highlight.rs
@@ -231,7 +231,7 @@ impl Highlighter for RustylineHelper {
 
             // println!("pos: {}")
 
-            let old_length = line_to_highlight.as_bytes().len();
+            let old_length = line_to_highlight.len();
 
             // self.bracket.set(check_bracket(&line_to_highlight, start));
 
@@ -239,7 +239,7 @@ impl Highlighter for RustylineHelper {
 
             line_to_highlight.replace_range(range, &highlighted);
 
-            let new_length = line_to_highlight.as_bytes().len();
+            let new_length = line_to_highlight.len();
 
             // TODO just store the updated location back in
             if let Some(pos) = paren_to_highlight {

--- a/crates/steel-repl/src/repl.rs
+++ b/crates/steel-repl/src/repl.rs
@@ -21,8 +21,6 @@ use std::env;
 
 use std::fs::File;
 
-use dirs;
-
 use crate::highlight::RustylineHelper;
 
 fn display_help() {
@@ -147,7 +145,7 @@ pub fn repl_base(mut vm: Engine) -> std::io::Result<()> {
 
     // Load repl history
     let history_path = get_repl_history_path();
-    if let Err(_) = rl.load_history(&history_path) {
+    if rl.load_history(&history_path).is_err() {
         if let Err(_) = File::create(&history_path) {
             eprintln!("Unable to create repl history file {:?}", history_path)
         }

--- a/examples/interior_mutability.rs
+++ b/examples/interior_mutability.rs
@@ -1,8 +1,4 @@
-use std::{
-    cell::RefCell,
-    rc::Rc,
-    sync::{Arc, Mutex},
-};
+use std::sync::{Arc, Mutex};
 
 use steel::steel_vm::engine::Engine;
 use steel::steel_vm::register_fn::RegisterFn;

--- a/examples/spellcheck.rs
+++ b/examples/spellcheck.rs
@@ -7,7 +7,6 @@ use steel_derive::Steel;
 use steel::steel_vm::engine::Engine;
 use steel_repl::run_repl;
 
-use std::cell::RefCell;
 use std::cmp::{max, min};
 use std::collections::HashMap;
 use std::process;

--- a/libs/steel-async-webrequests/src/lib.rs
+++ b/libs/steel-async-webrequests/src/lib.rs
@@ -144,9 +144,9 @@ impl Client {
                 }
                 .into_ffi()
             } else {
-                let message = format!(
+                let message =
                     "Expected a value of type finalized request, found another opaque object"
-                );
+                        .to_string();
                 async move { RResult::RErr(RBoxError::new(AsyncError::TypeMismatch(message))) }
                     .into_ffi()
             }
@@ -210,8 +210,8 @@ impl AsyncRequest {
 
         match inner {
             Some(Ok(inner)) => FinalizedAsyncRequest(Some(inner)).into_ffi_val(),
-            Some(Err(e)) => return RResult::RErr(RBoxError::new(e)),
-            None => return RResult::RErr(RBoxError::new(AsyncError::RequestAlreadyUsed)),
+            Some(Err(e)) => RResult::RErr(RBoxError::new(e)),
+            None => RResult::RErr(RBoxError::new(AsyncError::RequestAlreadyUsed)),
         }
     }
 }

--- a/libs/steel-markdown/src/lib.rs
+++ b/libs/steel-markdown/src/lib.rs
@@ -1,15 +1,12 @@
-use std::rc::Rc;
-
-use abi_stable::std_types::RBoxError;
 use steel::{
     gc::Shared,
-    rvals::{Custom, SerializableSteelVal},
+    rvals::Custom,
     steel_vm::ffi::{FFIModule, FFIValue, IntoFFIVal, RegisterFFIFn},
 };
 
 use pulldown_cmark::{CodeBlockKind, CowStr, Event, Options, Parser, Tag, TagEnd};
 
-use syntect::highlighting::{Color, ThemeSet};
+use syntect::highlighting::ThemeSet;
 use syntect::{html::highlighted_html_for_string, parsing::SyntaxSet};
 
 // fn main() {

--- a/libs/steel-rustls/src/lib.rs
+++ b/libs/steel-rustls/src/lib.rs
@@ -74,7 +74,6 @@ impl Clone for RustlsTcpStream {
     }
 }
 
-#[allow(unused)]
 #[derive(Debug)]
 enum RustlsError {
     Io(std::io::Error),

--- a/libs/steel-sqlite/src/lib.rs
+++ b/libs/steel-sqlite/src/lib.rs
@@ -142,7 +142,6 @@ impl Drop for SqliteTransaction {
     }
 }
 
-#[allow(unused)]
 #[derive(Debug)]
 enum SqliteError {
     TransactionAlreadyCompleted,

--- a/libs/steel-sqlite/src/lib.rs
+++ b/libs/steel-sqlite/src/lib.rs
@@ -272,7 +272,7 @@ impl std::fmt::Display for SqliteConversionError {
 impl std::error::Error for SqliteConversionError {}
 impl Custom for SqliteConnection {}
 
-impl<'a> ToSql for FFIWrapper<'a> {
+impl ToSql for FFIWrapper<'_> {
     fn to_sql(&self) -> rusqlite::Result<rusqlite::types::ToSqlOutput<'_>> {
         match &self.0 {
             // FFIValue::BoxedFunction(_) => todo!(),


### PR DESCRIPTION
This PR is the first (of probably many) that aims to bring steel closer to being able to run clippy as part of the CI.
Each crate will probably need its own PR for their remaining lint warnings and suggestions.

- Removes all those with level "error".
- Removes `#[allow(unused)]` annotations
- Runs a workspace-wide `cargo fix`