### PR TITLE
Update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1714906307,
-        "narHash": "sha256-UlRZtrCnhPFSJlDQE7M0eyhgvuuHBTe1eJ9N9AQlJQ0=",
+        "lastModified": 1736344531,
+        "narHash": "sha256-8YVQ9ZbSfuUk2bUf2KRj60NRraLPKPS0Q4QFTbc+c2c=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "25865a40d14b3f9cf19f19b924e2ab4069b09588",
+        "rev": "bffc22eb12172e6db3c5dde9e3e5628f8e3e7912",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Outdated nixpkgs returns:

> error: failed to parse lock file at: /build/source/Cargo.lock
       >
       > Caused by:
       >   lock file version 4 requires `-Znext-lockfile-bump`
       For full logs, run 'nix log /nix/store/zsm5jpr5pay5dds3jnczc0j879g8i601-steel-interpreter-0.6.0.drv'.

When building steel