### PR TITLE
support escaped identifiers

### DIFF
--- a/crates/steel-parser/src/lexer.rs
+++ b/crates/steel-parser/src/lexer.rs
@@ -2,6 +2,7 @@ use super::parser::SourceId;
 use crate::tokens::{IntLiteral, Token, TokenType};
 use crate::tokens::{NumberLiteral, Paren, ParenMod, RealLiteral};
 use smallvec::SmallVec;
+use std::borrow::Cow;
 use std::char;
 use std::iter::Iterator;
 use std::marker::PhantomData;
@@ -16,13 +17,13 @@ pub const NEG_NAN: &str = "-nan.0";
 pub struct OwnedString;
 
 impl ToOwnedString<String> for OwnedString {
-    fn own(&self, s: &str) -> String {
+    fn own(&self, s: Cow<str>) -> String {
         s.to_string()
     }
 }
 
 pub trait ToOwnedString<T> {
-    fn own(&self, s: &str) -> T;
+    fn own(&self, s: Cow<str>) -> T;
 }
 
 pub type Span = core::ops::Range<usize>;
@@ -33,7 +34,7 @@ pub struct Lexer<'a> {
     /// An iterator over the characters.
     chars: Peekable<Chars<'a>>,
     /// The  next token to return or `None` if it should be parsed.
-    queued: Option<TokenType<&'a str>>,
+    queued: Option<TokenType<Cow<'a, str>>>,
     token_start: usize,
     token_end: usize,
 }
@@ -71,7 +72,7 @@ impl<'a> Lexer<'a> {
         }
     }
 
-    fn read_string(&mut self) -> Result<TokenType<&'a str>> {
+    fn read_string(&mut self) -> Result<TokenType<Cow<'a, str>>> {
         // Skip the opening quote.
         self.eat();
 
@@ -81,113 +82,11 @@ impl<'a> Lexer<'a> {
             self.eat();
             match c {
                 '"' => return Ok(TokenType::StringLiteral(Arc::new(buf))),
-                '\\' => match self.chars.peek() {
-                    Some('"') => {
-                        self.eat();
-                        buf.push('"');
+                '\\' => {
+                    if let Some(c) = self.read_string_escape()? {
+                        buf.push(c);
                     }
-
-                    Some('a') => {
-                        self.eat();
-                        buf.push('\x07');
-                    }
-
-                    Some('b') => {
-                        self.eat();
-                        buf.push('\x08');
-                    }
-
-                    Some('\\') => {
-                        self.eat();
-                        buf.push('\\')
-                    }
-
-                    Some('|') => {
-                        self.eat();
-                        buf.push('|')
-                    }
-
-                    Some('t') => {
-                        self.eat();
-                        buf.push('\t');
-                    }
-
-                    Some('n') => {
-                        self.eat();
-                        buf.push('\n');
-                    }
-
-                    Some('r') => {
-                        self.eat();
-                        buf.push('\r');
-                    }
-
-                    Some('0') => {
-                        self.eat();
-                        buf.push('\0');
-                    }
-
-                    Some(&code @ ('x' | 'u')) => {
-                        self.eat();
-
-                        let mut digits = String::new();
-
-                        let braces = match self.chars.peek().copied() {
-                            Some('{') if code == 'u' => {
-                                self.eat();
-                                true
-                            }
-                            _ => false,
-                        };
-
-                        loop {
-                            let Some(c) = self.eat() else {
-                                return Err(TokenError::MalformedByteEscape);
-                            };
-
-                            match c {
-                                ';' if !braces => break,
-                                '}' if braces => break,
-                                c if c.is_ascii_digit() => {
-                                    digits.push(c);
-                                }
-                                'a'..='f' | 'A'..='F' => {
-                                    digits.push(c);
-                                }
-                                _ => return Err(TokenError::MalformedByteEscape),
-                            }
-                        }
-
-                        let codepoint = u32::from_str_radix(&digits, 16)
-                            .map_err(|_| TokenError::MalformedByteEscape)?;
-                        let char =
-                            char::from_u32(codepoint).ok_or(TokenError::MalformedByteEscape)?;
-
-                        buf.push(char);
-                    }
-
-                    Some(&start @ (' ' | '\t' | '\n')) => {
-                        self.eat();
-
-                        let mut trimming = start == '\n';
-
-                        while let Some(c) = self.chars.peek() {
-                            match c {
-                                ' ' | '\t' => {
-                                    self.eat();
-                                }
-                                '\n' if !trimming => {
-                                    self.eat();
-                                    trimming = true;
-                                }
-                                _ if trimming => break,
-                                _ => return Err(TokenError::IncompleteString),
-                            }
-                        }
-                    }
-
-                    _ => return Err(TokenError::InvalidEscape),
-                },
+                }
                 _ => buf.push(c),
             }
         }
@@ -195,7 +94,124 @@ impl<'a> Lexer<'a> {
         Err(TokenError::IncompleteString)
     }
 
-    fn read_hash_value(&mut self) -> Result<TokenType<&'a str>> {
+    fn read_string_escape(&mut self) -> Result<Option<char>> {
+        let c = match self.chars.peek() {
+            Some('"') => {
+                self.eat();
+                '"'
+            }
+
+            Some('a') => {
+                self.eat();
+                '\x07'
+            }
+
+            Some('b') => {
+                self.eat();
+                '\x08'
+            }
+
+            Some('\\') => {
+                self.eat();
+                '\\'
+            }
+
+            Some('|') => {
+                self.eat();
+                '|'
+            }
+
+            Some('t') => {
+                self.eat();
+                '\t'
+            }
+
+            Some('n') => {
+                self.eat();
+                '\n'
+            }
+
+            Some('r') => {
+                self.eat();
+                '\r'
+            }
+
+            Some('0') => {
+                self.eat();
+                '\0'
+            }
+
+            Some(&code @ ('x' | 'u')) => {
+                self.eat();
+
+                let mut digits = String::new();
+
+                let braces = match self.chars.peek().copied() {
+                    Some('{') if code == 'u' => {
+                        self.eat();
+                        true
+                    }
+                    _ => false,
+                };
+
+                loop {
+                    let Some(c) = self.eat() else {
+                        return Err(TokenError::MalformedByteEscape);
+                    };
+
+                    match c {
+                        ';' if !braces => break,
+                        '}' if braces => break,
+                        c if c.is_ascii_digit() => {
+                            digits.push(c);
+                        }
+                        'a'..='f' | 'A'..='F' => {
+                            digits.push(c);
+                        }
+                        _ => return Err(TokenError::MalformedByteEscape),
+                    }
+                }
+
+                let codepoint = u32::from_str_radix(&digits, 16)
+                    .map_err(|_| TokenError::MalformedByteEscape)?;
+                let char = char::from_u32(codepoint).ok_or(TokenError::MalformedByteEscape)?;
+
+                char
+            }
+
+            Some(&start @ (' ' | '\t' | '\n')) => {
+                self.eat();
+
+                let mut trimming = start == '\n';
+
+                loop {
+                    let Some(c) = self.chars.peek() else {
+                        return Err(TokenError::IncompleteString);
+                    };
+
+                    match c {
+                        ' ' | '\t' => {
+                            self.eat();
+                        }
+                        '\n' if !trimming => {
+                            self.eat();
+                            trimming = true;
+                        }
+                        _ if trimming => return Ok(None),
+
+                        // FIXME: not quite correct, it's a _malformed_ string
+                        _ => return Err(TokenError::IncompleteString),
+                    }
+                }
+            }
+
+            _ => return Err(TokenError::InvalidEscape),
+        };
+
+        Ok(Some(c))
+    }
+
+    fn read_hash_value(&mut self) -> Result<TokenType<Cow<'a, str>>> {
         fn parse_char(slice: &str) -> Option<char> {
             use std::str::FromStr;
 
@@ -303,7 +319,7 @@ impl<'a> Lexer<'a> {
                 Ok(IntLiteral::Small(hex).into())
             }
 
-            keyword if keyword.starts_with("#:") => Ok(TokenType::Keyword(self.slice())),
+            keyword if keyword.starts_with("#:") => Ok(TokenType::Keyword(self.slice().into())),
 
             character if character.starts_with("#\\") => {
                 if character.len() <= 2 {
@@ -327,14 +343,14 @@ impl<'a> Lexer<'a> {
                 Ok(TokenType::OpenParen(Paren::Round, Some(ParenMod::Bytes)))
             }
 
-            _ => Ok(self.read_word()),
+            _ => self.read_word(),
         }
     }
 
-    fn read_number(&mut self) -> TokenType<&'a str> {
+    fn read_number(&mut self) -> Result<TokenType<Cow<'a, str>>> {
         while let Some(&c) = self.chars.peek() {
             match c {
-                c if c.is_numeric() => {
+                c if c.is_ascii_digit() => {
                     self.eat();
                 }
                 '+' | '-' | '.' | '/' | 'e' | 'E' | 'i' => {
@@ -342,14 +358,14 @@ impl<'a> Lexer<'a> {
                 }
                 '(' | ')' | '[' | ']' => {
                     return if let Some(t) = parse_number(self.slice()) {
-                        t.into()
+                        Ok(t.into())
                     } else {
                         self.read_word()
                     }
                 }
                 c if c.is_whitespace() => {
                     return if let Some(t) = parse_number(self.slice()) {
-                        t.into()
+                        Ok(t.into())
                     } else {
                         self.read_word()
                     }
@@ -358,7 +374,7 @@ impl<'a> Lexer<'a> {
             }
         }
         match parse_number(self.slice()) {
-            Some(n) => n.into(),
+            Some(n) => Ok(n.into()),
             None => self.read_word(),
         }
     }
@@ -371,9 +387,33 @@ impl<'a> Lexer<'a> {
         }
     }
 
-    fn read_word(&mut self) -> TokenType<&'a str> {
+    fn read_word(&mut self) -> Result<TokenType<Cow<'a, str>>> {
+        let escaped_identifier = self.chars.peek().copied() == Some('|');
+
+        if escaped_identifier {
+            self.eat();
+        }
+
+        let mut ident_buffer = IdentBuffer::new(self.chars.clone());
+
         while let Some(&c) = self.chars.peek() {
             match c {
+                '|' if escaped_identifier => {
+                    self.eat();
+
+                    break;
+                }
+                '\\' if escaped_identifier => {
+                    self.eat();
+
+                    if let Some(c) = self.read_string_escape()? {
+                        ident_buffer.push_escape(c);
+                    }
+                }
+                c if escaped_identifier => {
+                    ident_buffer.push(c);
+                    self.eat();
+                }
                 '(' | '[' | ')' | ']' | '{' | '}' => break,
                 c if c.is_whitespace() => break,
                 '\'' | '"' | '`' | ';' | ',' => {
@@ -392,7 +432,7 @@ impl<'a> Lexer<'a> {
             };
         }
 
-        match self.slice() {
+        let token = match self.slice() {
             "." => TokenType::Dot,
             "define" | "defn" | "#%define" => TokenType::Define,
             "let" => TokenType::Let,
@@ -412,19 +452,33 @@ impl<'a> Lexer<'a> {
             NEG_INFINITY => RealLiteral::Float(f64::NEG_INFINITY).into(),
             NAN => RealLiteral::Float(f64::NAN).into(),
             NEG_NAN => RealLiteral::Float(f64::NAN).into(),
-            "|.|" => TokenType::Identifier("."),
             identifier => {
-                if identifier.len() > 1 && identifier.starts_with('+') && self.queued.is_none() {
-                    self.queued = Some(TokenType::Identifier(&identifier[1..]));
-                    TokenType::Identifier("+")
-                } else {
-                    TokenType::Identifier(identifier)
+                debug_assert!(!identifier.is_empty());
+
+                match identifier.as_bytes() {
+                    [b'+', _, ..] if self.queued.is_none() => {
+                        self.queued = Some(TokenType::Identifier((&identifier[1..]).into()));
+                        TokenType::Identifier("+".into())
+                    }
+                    [b'|', .., b'|'] if escaped_identifier => {
+                        if ident_buffer.ident.is_empty() {
+                            TokenType::Identifier((&identifier[1..identifier.len() - 1]).into())
+                        } else {
+                            TokenType::Identifier(ident_buffer.ident.into())
+                        }
+                    }
+                    _ if escaped_identifier => {
+                        return Err(TokenError::IncompleteIdentifier);
+                    }
+                    _ => TokenType::Identifier(identifier.into()),
                 }
             }
-        }
+        };
+
+        Ok(token)
     }
 
-    fn read_nestable_comment(&mut self) -> Result<TokenType<&'a str>> {
+    fn read_nestable_comment(&mut self) -> Result<TokenType<Cow<'a, str>>> {
         self.eat();
 
         let mut depth = 1;
@@ -452,6 +506,42 @@ impl<'a> Lexer<'a> {
         }
 
         Err(TokenError::IncompleteComment)
+    }
+}
+
+struct IdentBuffer<'a> {
+    chars: Peekable<Chars<'a>>,
+    ident: String,
+    // works as Either:
+    //  - Ok: saw a non-trivial escape, buffering into ident
+    //  - Err: "trivial" string, keeping count of its len
+    mode: std::result::Result<(), usize>,
+}
+
+impl<'a> IdentBuffer<'a> {
+    fn new(chars: Peekable<Chars<'a>>) -> Self {
+        Self {
+            chars,
+            ident: Default::default(),
+            mode: Err(0),
+        }
+    }
+
+    fn push(&mut self, c: char) {
+        if let Err(len) = self.mode.as_mut() {
+            *len += 1;
+        } else {
+            self.ident.push(c);
+        }
+    }
+
+    fn push_escape(&mut self, c: char) {
+        if let Err(len) = self.mode {
+            self.ident.extend(self.chars.clone().take(len));
+            self.mode = Ok(());
+        }
+
+        self.ident.push(c);
     }
 }
 
@@ -547,7 +637,7 @@ impl<'a, T, F: ToOwnedString<T>> OwnedTokenStream<'a, T, F> {
     }
 }
 impl<'a> Iterator for TokenStream<'a> {
-    type Item = Token<'a, &'a str>;
+    type Item = Token<'a, Cow<'a, str>>;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.lexer.next().and_then(|token| {
@@ -573,6 +663,7 @@ pub type Result<T> = std::result::Result<T, TokenError>;
 pub enum TokenError {
     UnexpectedChar(char),
     IncompleteString,
+    IncompleteIdentifier,
     IncompleteComment,
     InvalidEscape,
     InvalidCharacter,
@@ -583,7 +674,7 @@ pub enum TokenError {
 }
 
 impl<'a> Iterator for Lexer<'a> {
-    type Item = Result<TokenType<&'a str>>;
+    type Item = Result<TokenType<Cow<'a, str>>>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if let Some(t) = self.queued.take() {
@@ -648,8 +739,8 @@ impl<'a> Iterator for Lexer<'a> {
             Some('+') | Some('-') => {
                 self.eat();
                 match self.chars.peek() {
-                    Some(&c) if c.is_numeric() => Some(Ok(self.read_number())),
-                    _ => Some(Ok(self.read_word())),
+                    Some(&c) if c.is_ascii_digit() => Some(self.read_number()),
+                    _ => Some(self.read_word()),
                 }
             }
             Some('#') => {
@@ -668,10 +759,10 @@ impl<'a> Iterator for Lexer<'a> {
                 Some(token)
             }
 
-            Some(c) if !c.is_whitespace() && !c.is_numeric() || *c == '_' => {
-                Some(Ok(self.read_word()))
+            Some(c) if !c.is_whitespace() && !c.is_ascii_digit() || *c == '_' => {
+                Some(self.read_word())
             }
-            Some(c) if c.is_numeric() => Some(Ok(self.read_number())),
+            Some(c) if c.is_ascii_digit() => Some(self.read_number()),
             Some(_) => self.eat().map(|e| Err(TokenError::UnexpectedChar(e))),
             None => None,
         }
@@ -784,6 +875,10 @@ mod lexer_tests {
     use crate::span::Span;
     use crate::tokens::{IntLiteral, TokenType::*};
     use pretty_assertions::assert_eq;
+
+    fn identifier(ident: &str) -> TokenType<Cow<str>> {
+        Identifier(ident.into())
+    }
 
     // TODO: Figure out why this just cause an infinite loop when parsing it?
     #[test]
@@ -992,7 +1087,7 @@ mod lexer_tests {
         assert_eq!(
             s.next(),
             Some(Token {
-                ty: Identifier("$"),
+                ty: identifier("$"),
                 source: "$",
                 span: Span::new(1, 2, SourceId::none())
             })
@@ -1014,7 +1109,7 @@ mod lexer_tests {
         assert_eq!(
             s.next(),
             Some(Token {
-                ty: Identifier("foo"),
+                ty: identifier("foo"),
                 source: "foo",
                 span: Span::new(0, 3, SourceId::none())
             })
@@ -1023,7 +1118,7 @@ mod lexer_tests {
         assert_eq!(
             s.next(),
             Some(Token {
-                ty: Identifier("FOO"),
+                ty: identifier("FOO"),
                 source: "FOO",
                 span: Span::new(4, 7, SourceId::none())
             })
@@ -1032,7 +1127,7 @@ mod lexer_tests {
         assert_eq!(
             s.next(),
             Some(Token {
-                ty: Identifier("_123_"),
+                ty: identifier("_123_"),
                 source: "_123_",
                 span: Span::new(8, 13, SourceId::none())
             })
@@ -1041,7 +1136,7 @@ mod lexer_tests {
         assert_eq!(
             s.next(),
             Some(Token {
-                ty: Identifier("Nil"),
+                ty: identifier("Nil"),
                 source: "Nil",
                 span: Span::new(14, 17, SourceId::none())
             })
@@ -1077,37 +1172,37 @@ mod lexer_tests {
             got.as_slice(),
             &[
                 Token {
-                    ty: Identifier("1e"),
+                    ty: identifier("1e"),
                     source: "1e",
                     span: Span::new(0, 2, SourceId::none()),
                 },
                 Token {
-                    ty: Identifier("1ee"),
+                    ty: identifier("1ee"),
                     source: "1ee",
                     span: Span::new(3, 6, SourceId::none()),
                 },
                 Token {
-                    ty: Identifier("1.2e5.4"),
+                    ty: identifier("1.2e5.4"),
                     source: "1.2e5.4",
                     span: Span::new(7, 14, SourceId::none()),
                 },
                 Token {
-                    ty: Identifier("1E10/4"),
+                    ty: identifier("1E10/4"),
                     source: "1E10/4",
                     span: Span::new(15, 21, SourceId::none()),
                 },
                 Token {
-                    ty: Identifier("1.45#"),
+                    ty: identifier("1.45#"),
                     source: "1.45#",
                     span: Span::new(22, 27, SourceId::none()),
                 },
                 Token {
-                    ty: Identifier("3-"),
+                    ty: identifier("3-"),
                     source: "3-",
                     span: Span::new(28, 30, SourceId::none()),
                 },
                 Token {
-                    ty: Identifier("e10"),
+                    ty: identifier("e10"),
                     source: "e10",
                     span: Span::new(31, 34, SourceId::none()),
                 },
@@ -1271,22 +1366,22 @@ mod lexer_tests {
                     span: Span::new(63, 104, SourceId::none()),
                 },
                 Token {
-                    ty: Identifier("/"),
+                    ty: identifier("/"),
                     source: "/",
                     span: Span::new(121, 122, SourceId::none()),
                 },
                 Token {
-                    ty: Identifier("1/"),
+                    ty: identifier("1/"),
                     source: "1/",
                     span: Span::new(139, 141, SourceId::none()),
                 },
                 Token {
-                    ty: Identifier("1/4.0"),
+                    ty: identifier("1/4.0"),
                     source: "1/4.0",
                     span: Span::new(158, 163, SourceId::none()),
                 },
                 Token {
-                    ty: Identifier("1//4"),
+                    ty: identifier("1//4"),
                     source: "1//4",
                     span: Span::new(180, 184, SourceId::none()),
                 },
@@ -1296,7 +1391,7 @@ mod lexer_tests {
                     span: Span::new(201, 202, SourceId::none()),
                 },
                 Token {
-                    ty: Identifier("/"),
+                    ty: identifier("/"),
                     source: "/",
                     span: Span::new(203, 204, SourceId::none()),
                 },
@@ -1395,27 +1490,27 @@ mod lexer_tests {
             got.as_slice(),
             &[
                 Token {
-                    ty: Identifier("i"),
+                    ty: identifier("i"),
                     source: "i",
                     span: Span::new(0, 1, SourceId::none()),
                 },
                 Token {
-                    ty: Identifier("-i"),
+                    ty: identifier("-i"),
                     source: "-i",
                     span: Span::new(2, 4, SourceId::none()),
                 },
                 Token {
-                    ty: Identifier("1i+1i"),
+                    ty: identifier("1i+1i"),
                     source: "1i+1i",
                     span: Span::new(5, 10, SourceId::none()),
                 },
                 Token {
-                    ty: Identifier("4+i"),
+                    ty: identifier("4+i"),
                     source: "4+i",
                     span: Span::new(11, 14, SourceId::none()),
                 },
                 Token {
-                    ty: Identifier("-4+-2i"),
+                    ty: identifier("-4+-2i"),
                     source: "-4+-2i",
                     span: Span::new(15, 21, SourceId::none()),
                 },
@@ -1462,7 +1557,7 @@ mod lexer_tests {
             true,
             SourceId::none(),
         );
-        let res: Vec<Token<&str>> = s.collect();
+        let res: Vec<Token<Cow<str>>> = s.collect();
 
         println!("{:#?}", res);
     }
@@ -1470,23 +1565,23 @@ mod lexer_tests {
     #[test]
     fn lex_string_with_escape_chars() {
         let s = TokenStream::new("\"\0\0\0\"", true, SourceId::none());
-        let res: Vec<Token<&str>> = s.collect();
+        let res: Vec<Token<Cow<str>>> = s.collect();
         println!("{:#?}", res);
     }
 
     #[test]
     fn scheme_statement() {
         let s = TokenStream::new("(apples (function a b) (+ a b))", true, SourceId::none());
-        let res: Vec<Token<&str>> = s.collect();
+        let res: Vec<Token<Cow<str>>> = s.collect();
 
-        let expected: Vec<Token<&str>> = vec![
+        let expected: Vec<Token<Cow<str>>> = vec![
             Token {
                 ty: OpenParen(Paren::Round, None),
                 source: "(",
                 span: Span::new(0, 1, SourceId::none()),
             },
             Token {
-                ty: Identifier("apples"),
+                ty: identifier("apples"),
                 source: "apples",
                 span: Span::new(1, 7, SourceId::none()),
             },
@@ -1496,17 +1591,17 @@ mod lexer_tests {
                 span: Span::new(8, 9, SourceId::none()),
             },
             Token {
-                ty: Identifier("function"),
+                ty: identifier("function"),
                 source: "function",
                 span: Span::new(9, 17, SourceId::none()),
             },
             Token {
-                ty: Identifier("a"),
+                ty: identifier("a"),
                 source: "a",
                 span: Span::new(18, 19, SourceId::none()),
             },
             Token {
-                ty: Identifier("b"),
+                ty: identifier("b"),
                 source: "b",
                 span: Span::new(20, 21, SourceId::none()),
             },
@@ -1521,17 +1616,17 @@ mod lexer_tests {
                 span: Span::new(23, 24, SourceId::none()),
             },
             Token {
-                ty: Identifier("+"),
+                ty: identifier("+"),
                 source: "+",
                 span: Span::new(24, 25, SourceId::none()),
             },
             Token {
-                ty: Identifier("a"),
+                ty: identifier("a"),
                 source: "a",
                 span: Span::new(26, 27, SourceId::none()),
             },
             Token {
-                ty: Identifier("b"),
+                ty: identifier("b"),
                 source: "b",
                 span: Span::new(28, 29, SourceId::none()),
             },
@@ -1553,11 +1648,11 @@ mod lexer_tests {
     #[test]
     fn test_bigint() {
         let s = TokenStream::new("9223372036854775808", true, SourceId::none()); // isize::MAX + 1
-        let res: Vec<Token<&str>> = s.collect();
+        let res: Vec<Token<Cow<str>>> = s.collect();
 
         let expected_bigint = Box::new("9223372036854775808".parse().unwrap());
 
-        let expected: Vec<Token<&str>> = vec![Token {
+        let expected: Vec<Token<Cow<str>>> = vec![Token {
             ty: IntLiteral::Big(expected_bigint).into(),
             source: "9223372036854775808",
             span: Span::new(0, 19, SourceId::none()),
@@ -1569,11 +1664,11 @@ mod lexer_tests {
     #[test]
     fn negative_test_bigint() {
         let s = TokenStream::new("-9223372036854775809", true, SourceId::none()); // isize::MIN - 1
-        let res: Vec<Token<&str>> = s.collect();
+        let res: Vec<Token<Cow<str>>> = s.collect();
 
         let expected_bigint = Box::new("-9223372036854775809".parse().unwrap());
 
-        let expected: Vec<Token<&str>> = vec![Token {
+        let expected: Vec<Token<Cow<str>>> = vec![Token {
             ty: IntLiteral::Big(expected_bigint).into(),
             source: "-9223372036854775809",
             span: Span::new(0, 20, SourceId::none()),
@@ -1586,27 +1681,27 @@ mod lexer_tests {
     fn identifier_test() {
         let s = TokenStream::new("a b(c`d'e\"www\"f,g;", true, SourceId::none());
 
-        let tokens: Vec<(TokenType<&str>, &str)> =
+        let tokens: Vec<(TokenType<Cow<str>>, &str)> =
             s.map(|token| (token.ty, token.source)).collect();
 
-        assert_eq!(tokens[0], (TokenType::Identifier("a"), "a"));
-        assert_eq!(tokens[1], (TokenType::Identifier("b"), "b"));
-        assert_eq!(tokens[3], (TokenType::Identifier("c"), "c"));
-        assert_eq!(tokens[5], (TokenType::Identifier("d"), "d"));
-        assert_eq!(tokens[7], (TokenType::Identifier("e"), "e"));
-        assert_eq!(tokens[9], (TokenType::Identifier("f"), "f"));
-        assert_eq!(tokens[11], (TokenType::Identifier("g"), "g"));
+        assert_eq!(tokens[0], (identifier("a"), "a"));
+        assert_eq!(tokens[1], (identifier("b"), "b"));
+        assert_eq!(tokens[3], (identifier("c"), "c"));
+        assert_eq!(tokens[5], (identifier("d"), "d"));
+        assert_eq!(tokens[7], (identifier("e"), "e"));
+        assert_eq!(tokens[9], (identifier("f"), "f"));
+        assert_eq!(tokens[11], (identifier("g"), "g"));
     }
 
     #[test]
     fn vector_test() {
         let s = TokenStream::new("a b #(c d)", true, None);
 
-        let tokens: Vec<(TokenType<&str>, &str)> =
+        let tokens: Vec<(TokenType<Cow<str>>, &str)> =
             s.map(|token| (token.ty, token.source)).collect();
 
-        assert_eq!(tokens[0], (TokenType::Identifier("a"), "a"));
-        assert_eq!(tokens[1], (TokenType::Identifier("b"), "b"));
+        assert_eq!(tokens[0], (identifier("a"), "a"));
+        assert_eq!(tokens[1], (identifier("b"), "b"));
         assert_eq!(
             tokens[2],
             (
@@ -1614,19 +1709,19 @@ mod lexer_tests {
                 "#("
             )
         );
-        assert_eq!(tokens[3], (TokenType::Identifier("c"), "c"));
-        assert_eq!(tokens[4], (TokenType::Identifier("d"), "d"));
+        assert_eq!(tokens[3], (identifier("c"), "c"));
+        assert_eq!(tokens[4], (identifier("d"), "d"));
     }
 
     #[test]
     fn bytevector_test() {
         let s = TokenStream::new("a b #u8(1 2)", true, None);
 
-        let tokens: Vec<(TokenType<&str>, &str)> =
+        let tokens: Vec<(TokenType<Cow<str>>, &str)> =
             s.map(|token| (token.ty, token.source)).collect();
 
-        assert_eq!(tokens[0], (TokenType::Identifier("a"), "a"));
-        assert_eq!(tokens[1], (TokenType::Identifier("b"), "b"));
+        assert_eq!(tokens[0], (identifier("a"), "a"));
+        assert_eq!(tokens[1], (identifier("b"), "b"));
         assert_eq!(
             tokens[2],
             (
@@ -1635,22 +1730,6 @@ mod lexer_tests {
             )
         );
         assert_eq!(tokens[5], (TokenType::CloseParen(Paren::Round), ")"));
-    }
-
-    #[test]
-    fn escaped_identifier_test() {
-        let token = TokenStream::new("|.|", true, SourceId::none())
-            .next()
-            .unwrap();
-
-        assert_eq!(
-            token,
-            Token {
-                ty: TokenType::Identifier("."),
-                source: "|.|",
-                span: Span::new(0, 3, SourceId::none())
-            }
-        )
     }
 
     #[test]
@@ -1676,5 +1755,46 @@ mod lexer_tests {
         let mut lexer = Lexer::new("#|");
 
         assert_eq!(lexer.next().unwrap(), Err(TokenError::IncompleteComment));
+    }
+
+    #[test]
+    fn escaped_identifier_test() {
+        let mut s = TokenStream::new(r#"|a| |a b| |\x61;| |.|"#, true, SourceId::none());
+
+        assert_eq!(
+            s.next().unwrap(),
+            Token {
+                ty: identifier("a"),
+                source: "|a|",
+                span: Span::new(0, 3, None),
+            },
+        );
+
+        assert_eq!(
+            s.next().unwrap(),
+            Token {
+                ty: identifier("a b"),
+                source: "|a b|",
+                span: Span::new(4, 9, None),
+            },
+        );
+
+        assert_eq!(
+            s.next().unwrap(),
+            Token {
+                ty: identifier("a"),
+                source: r#"|\x61;|"#,
+                span: Span::new(10, 17, None),
+            },
+        );
+
+        assert_eq!(
+            s.next().unwrap(),
+            Token {
+                ty: identifier("."),
+                source: "|.|",
+                span: Span::new(18, 21, None),
+            },
+        );
     }
 }

--- a/crates/steel-parser/src/parser.rs
+++ b/crates/steel-parser/src/parser.rs
@@ -1,4 +1,5 @@
 use std::{
+    borrow::Cow,
     path::PathBuf,
     rc::Rc,
     result,
@@ -269,8 +270,8 @@ impl ParseError {
 pub struct InternString;
 
 impl ToOwnedString<InternedString> for InternString {
-    fn own(&self, s: &str) -> InternedString {
-        s.into()
+    fn own(&self, s: Cow<str>) -> InternedString {
+        (&*s).into()
     }
 }
 

--- a/crates/steel-parser/src/tokens.rs
+++ b/crates/steel-parser/src/tokens.rs
@@ -4,6 +4,7 @@ use crate::span::Span;
 use core::ops;
 use num::{BigInt, Rational32, Signed};
 use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
 use std::fmt::{self, Display};
 use std::str::FromStr;
 use std::sync::Arc;
@@ -271,7 +272,7 @@ impl From<BigInt> for IntLiteral {
     }
 }
 
-impl<'a> TokenType<&'a str> {
+impl<'a> TokenType<Cow<'a, str>> {
     pub fn open_span(mut span: Span, paren_mod: Option<ParenMod>) -> Span {
         let offset = match paren_mod {
             Some(ParenMod::Vector) => 1,
@@ -284,7 +285,7 @@ impl<'a> TokenType<&'a str> {
         span
     }
 
-    pub fn to_owned<T: From<&'a str>>(self) -> TokenType<T> {
+    pub fn to_owned<T: From<Cow<'a, str>>>(self) -> TokenType<T> {
         match self {
             TokenType::Identifier(i) => TokenType::Identifier(i.into()),
             TokenType::Keyword(i) => TokenType::Keyword(i.into()),
@@ -322,7 +323,7 @@ impl<'a> TokenType<&'a str> {
         }
     }
 
-    pub fn map<T>(self, mut func: impl FnMut(&'a str) -> T) -> TokenType<T> {
+    pub fn map<T>(self, mut func: impl FnMut(Cow<'a, str>) -> T) -> TokenType<T> {
         match self {
             TokenType::Identifier(i) => TokenType::Identifier(func(i)),
             TokenType::Keyword(i) => TokenType::Keyword(func(i)),

--- a/crates/steel-repl/src/highlight.rs
+++ b/crates/steel-repl/src/highlight.rs
@@ -200,7 +200,7 @@ impl Highlighter for RustylineHelper {
                         .globals
                         .lock()
                         .unwrap()
-                        .contains(&InternedString::from(*ident))
+                        .contains(&InternedString::from(&**ident))
                     {
                         let highlighted = format!("{}", token.source().bright_blue());
                         ranges_to_replace.push((token.span().range(), highlighted));


### PR DESCRIPTION
adds support for escaped identifiers such as `|foo bar|`.