### PR TITLE
Repl: Colored prompt on windows

### DIFF
--- a/crates/steel-repl/src/repl.rs
+++ b/crates/steel-repl/src/repl.rs
@@ -187,10 +187,6 @@ pub fn readline_module(vm: &mut Engine) {
 pub fn repl_base(mut vm: Engine) -> std::io::Result<()> {
     display_startup();
 
-    #[cfg(target_os = "windows")]
-    let mut prompt = String::from("λ > ");
-
-    #[cfg(not(target_os = "windows"))]
     let mut prompt = format!("{}", "λ > ".bright_green().bold().italic());
 
     let mut rl = Editor::<RustylineHelper, rustyline::history::DefaultHistory>::new()


### PR DESCRIPTION
`colored` supports Windows (by calling `SetConsoleMode`) and is already used to display the greeting.