### PR TITLE
Repl: completions for globals

### DIFF
--- a/crates/steel-repl/src/highlight.rs
+++ b/crates/steel-repl/src/highlight.rs
@@ -2,6 +2,7 @@ extern crate rustyline;
 use colored::*;
 use steel_parser::interner::InternedString;
 use steel_parser::parser::SourceId;
+use steel_parser::tokens::TokenType;
 
 use std::collections::HashSet;
 use std::sync::{Arc, Mutex};
@@ -19,10 +20,6 @@ use rustyline::completion::Pair;
 
 use std::borrow::Cow;
 
-impl Completer for RustylineHelper {
-    type Candidate = Pair;
-}
-
 #[derive(Helper)]
 pub struct RustylineHelper {
     globals: Arc<Mutex<HashSet<InternedString>>>,
@@ -34,6 +31,80 @@ impl RustylineHelper {
         Self {
             globals,
             bracket: crossbeam::atomic::AtomicCell::new(None),
+        }
+    }
+}
+
+impl Completer for RustylineHelper {
+    type Candidate = Pair;
+
+    fn complete(
+        &self,
+        line: &str,
+        pos: usize,
+        _ctx: &Context<'_>,
+    ) -> rustyline::Result<(usize, Vec<Self::Candidate>)> {
+        // Only do completions if we're in an identifier
+        let Some((span, symbol)) =
+            TokenStream::new(line, true, SourceId::none()).find_map(|token| match token.ty {
+                TokenType::Identifier(symbol) => (
+                    // Inclusive range as curser usually placed directly after the symbol
+                    token.span().start()..=token.span().end()
+                )
+                    .contains(&pos)
+                    .then_some((token.span(), symbol)),
+                _ => None,
+            })
+        else {
+            return Ok((0, Vec::new()));
+        };
+
+        // Find all globals containing the identifier the user is currently typing
+        let mut starting = Vec::new();
+        let mut containing = Vec::new();
+        for interned in self.globals.lock().unwrap().iter() {
+            let str = interned.resolve();
+            if str.starts_with(symbol) {
+                starting.push(str.to_owned());
+            } else if str.contains(symbol) {
+                containing.push(str.to_owned())
+            }
+        }
+
+        // Sort identifiers, present the ones that only require completing the end first
+        let compare = |a: &String, b: &String| {
+            a.contains("builtin")
+                .cmp(&b.contains("builtin"))
+                .then(a.starts_with('#').cmp(&b.starts_with('#')))
+                .then(a.cmp(b))
+        };
+        starting.sort_by(compare);
+        containing.sort_by(compare);
+        let candidates = starting.into_iter().chain(containing.into_iter());
+
+        // Apply colors to distinguish completion from typed text
+        let completions = candidates
+            .map(|ident| Pair {
+                display: format!("{}", ident.white()),
+                replacement: ident,
+            })
+            .collect();
+
+        Ok((span.start(), completions))
+    }
+
+    fn update(
+        &self,
+        line: &mut rustyline::line_buffer::LineBuffer,
+        start: usize,
+        elected: &str,
+        cl: &mut rustyline::Changeset,
+    ) {
+        // Cursor can be anywhere in the identifier, so find its span again.
+        if let Some(end) = TokenStream::new(line, true, SourceId::none())
+            .find_map(|token| (token.span().start() == start).then_some(token.span().end()))
+        {
+            line.replace(start..end, elected, cl);
         }
     }
 }


### PR DESCRIPTION
I'm trying to use Steel to learn Scheme, but I don't know what functions are available, so this PR makes the repl tell me.

As I don't yet know all the naming conventions in Scheme & Steel, there may be a better priorisation order for the completions.

I've kept this in the `highlight` module as it defines the `RustylineHelper`, but it might be worth pulling it out into a separate small module.

This impl doesn't complete names of macros; I'm not sure yet how they're handled – they aren't highlighted currently.