### PR TITLE
Moved functions from NumOperations to use derive | numbers.rs

### DIFF
--- a/crates/steel-core/src/primitives.rs
+++ b/crates/steel-core/src/primitives.rs
@@ -52,9 +52,7 @@ pub use io::IoFunctions;
 pub use lists::UnRecoverableResult;
 pub use meta_ops::MetaOperations;
 use num::{BigInt, BigRational, Rational32, ToPrimitive};
-pub use numbers::{
-    add_primitive, divide_primitive, multiply_primitive, subtract_primitive, NumOperations,
-};
+pub use numbers::{add_primitive, divide_primitive, multiply_primitive, subtract_primitive};
 pub use ports::port_module;
 use std::convert::TryFrom;
 use std::result;

--- a/crates/steel-core/src/primitives/numbers.rs
+++ b/crates/steel-core/src/primitives/numbers.rs
@@ -1243,7 +1243,19 @@ where
     (x, rem)
 }
 
-///COMMENT THIS
+/// Performs a bitwise arithmetic shift on the given 2 numbers
+///
+/// (arithmetic-shift n m) -> integer?
+///
+/// * n : integer? - The number to shift.
+/// * m : integer? - The number by which to shift.
+///
+/// # Examples
+/// ```scheme
+/// > (arithmetic-shift 10 1) ;; => 20
+/// > (arithmetic-shift 20 1) ;; => 40
+/// > (arithmetic-shift 40 -2) ;; => 10
+/// ```
 #[steel_derive::native(name = "arithmetic-shift", constant = true, arity = "Exact(2)")]
 pub fn arithmetic_shift(args: &[SteelVal]) -> Result<SteelVal> {
     match &args {
@@ -1261,7 +1273,18 @@ pub fn arithmetic_shift(args: &[SteelVal]) -> Result<SteelVal> {
     }
 }
 
-///COMMENT THIS
+/// Checks if the given number is even
+///
+/// (even? n) -> bool?
+///
+/// * n : number? - The number to check for evenness.
+///
+/// # Examples
+/// ```scheme
+/// > (even? 2) ;; => #true
+/// > (even? 3) ;; => #false
+/// > (even? 4.0) ;; => #true
+/// ```
 #[steel_derive::function(name = "even?", constant = true)]
 pub fn even(arg: &SteelVal) -> Result<SteelVal> {
     match arg {
@@ -1272,6 +1295,18 @@ pub fn even(arg: &SteelVal) -> Result<SteelVal> {
     }
 }
 
+/// Checks if the given number is odd
+///
+/// (odd? n) -> bool?
+///
+/// * n : number? - The number to check for oddness.
+///
+/// # Examples
+/// ```scheme
+/// > (odd? 2) ;; => #false
+/// > (odd? 3) ;; => #true
+/// > (odd? 5.0) ;; => #true
+/// ```
 #[steel_derive::function(name = "odd?", constant = true)]
 pub fn odd(arg: &SteelVal) -> Result<SteelVal> {
     match arg {
@@ -1284,6 +1319,18 @@ pub fn odd(arg: &SteelVal) -> Result<SteelVal> {
     }
 }
 
+/// Sums all given floats
+///
+/// (f+ nums) -> number?
+///
+/// * nums : float? - The floats to sum up.
+///
+/// # Examples
+/// ```scheme
+/// > (f+ 5.5) ;; => 5.5
+/// > (f+ 1.1 2.2) ;; => 3.3
+/// > (f+ 3.3 3.3 3.3) ;; => 9.9
+/// ```
 #[steel_derive::native(name = "f+", constant = true, arity = "AtLeast(1)")]
 pub fn float_add(args: &[SteelVal]) -> Result<SteelVal> {
     if args.is_empty() {

--- a/crates/steel-core/src/primitives/numbers.rs
+++ b/crates/steel-core/src/primitives/numbers.rs
@@ -1243,7 +1243,7 @@ where
     (x, rem)
 }
 
-/// Performs a bitwise arithmetic shift on the given 2 numbers
+/// Performs a bitwise arithmetic shift using the given 2 numbers
 ///
 /// (arithmetic-shift n m) -> integer?
 ///

--- a/crates/steel-core/src/primitives/numbers.rs
+++ b/crates/steel-core/src/primitives/numbers.rs
@@ -1532,25 +1532,19 @@ pub fn arithmetic_shift(args: &[SteelVal]) -> Result<SteelVal> {
     }
 }
 
+///COMMENT THIS
+#[steel_derive::function(name = "even?", constant = true)]
+pub fn even(arg: &SteelVal) -> Result<SteelVal> {
+    match arg {
+        SteelVal::IntV(n) => Ok(SteelVal::BoolV(n & 1 == 0)),
+        SteelVal::BigNum(n) => Ok(SteelVal::BoolV(n.is_even())),
+        SteelVal::NumV(n) if n.fract() == 0.0 => (*n as i64).is_even().into_steelval(),
+        _ => steelerr!(TypeMismatch => "even? requires an integer, found: {:?}", arg),
+    }
+}
+
 pub struct NumOperations {}
 impl NumOperations {
-    pub fn even() -> SteelVal {
-        SteelVal::FuncV(|args: &[SteelVal]| -> Result<SteelVal> {
-            if args.len() != 1 {
-                stop!(ArityMismatch => "even? takes one argument")
-            }
-
-            match &args[0] {
-                SteelVal::IntV(n) => Ok(SteelVal::BoolV(n & 1 == 0)),
-                SteelVal::BigNum(n) => Ok(SteelVal::BoolV(n.is_even())),
-                SteelVal::NumV(n) if n.fract() == 0.0 => (*n as i64).is_even().into_steelval(),
-                _ => {
-                    steelerr!(TypeMismatch => format!("even? requires an integer, found: {:?}", &args[0]))
-                }
-            }
-        })
-    }
-
     pub fn odd() -> SteelVal {
         SteelVal::FuncV(|args: &[SteelVal]| -> Result<SteelVal> {
             if args.len() != 1 {

--- a/crates/steel-core/src/primitives/numbers.rs
+++ b/crates/steel-core/src/primitives/numbers.rs
@@ -1514,29 +1514,26 @@ fn add_complex(x: &SteelComplex, y: &SteelComplex) -> Result<SteelVal> {
     SteelComplex::new(add_two(&x.re, &y.re)?, add_two(&x.im, &y.im)?).into_steelval()
 }
 
+///COMMENT THIS
+#[steel_derive::native(name = "arithmetic-shift", constant = true, arity = "Exact(2)")]
+pub fn arithmetic_shift(args: &[SteelVal]) -> Result<SteelVal> {
+    match &args {
+        [n, m] => match (n, m) {
+            (SteelVal::IntV(n), SteelVal::IntV(m)) => {
+                if *m >= 0 {
+                    Ok(SteelVal::IntV(n << m))
+                } else {
+                    Ok(SteelVal::IntV(n >> -m))
+                }
+            }
+            _ => stop!(TypeMismatch => "arithmetic-shift expected 2 integers"),
+        },
+        _ => stop!(ArityMismatch => "arithmetic-shift takes 2 arguments"),
+    }
+}
+
 pub struct NumOperations {}
 impl NumOperations {
-    pub fn arithmetic_shift() -> SteelVal {
-        SteelVal::FuncV(|args: &[SteelVal]| -> Result<SteelVal> {
-            if args.len() != 2 {
-                stop!(ArityMismatch => "arithmetic-shift takes 2 arguments")
-            }
-            let n = args[0].clone();
-            let m = args[1].clone();
-
-            match (n, m) {
-                (SteelVal::IntV(n), SteelVal::IntV(m)) => {
-                    if m >= 0 {
-                        Ok(SteelVal::IntV(n << m))
-                    } else {
-                        Ok(SteelVal::IntV(n >> -m))
-                    }
-                }
-                _ => steelerr!(TypeMismatch => "arithmetic-shift expected 2 integers"),
-            }
-        })
-    }
-
     pub fn even() -> SteelVal {
         SteelVal::FuncV(|args: &[SteelVal]| -> Result<SteelVal> {
             if args.len() != 1 {

--- a/crates/steel-core/src/steel_vm/primitives.rs
+++ b/crates/steel-core/src/steel_vm/primitives.rs
@@ -1041,7 +1041,7 @@ fn number_module() -> BuiltInModule {
         .register_native_fn_definition(numbers::MULTIPLY_PRIMITIVE_DEFINITION)
         .register_native_fn_definition(numbers::DIVIDE_PRIMITIVE_DEFINITION)
         .register_native_fn_definition(numbers::SUBTRACT_PRIMITIVE_DEFINITION)
-        .register_value("even?", NumOperations::even())
+        .register_native_fn_definition(numbers::EVEN_DEFINITION)
         .register_value("odd?", NumOperations::odd())
         .register_native_fn_definition(numbers::ARITHMETIC_SHIFT_DEFINITION)
         .register_native_fn_definition(numbers::ABS_DEFINITION)

--- a/crates/steel-core/src/steel_vm/primitives.rs
+++ b/crates/steel-core/src/steel_vm/primitives.rs
@@ -41,8 +41,8 @@ use crate::{
             MUT_VEC_LENGTH_DEFINITION, MUT_VEC_SET_DEFINITION, MUT_VEC_TO_LIST_DEFINITION,
             VECTOR_FILL_DEFINITION, VEC_LENGTH_DEFINITION,
         },
-        ControlOperations, IoFunctions, MetaOperations, NumOperations, StreamOperations,
-        SymbolOperations, VectorOperations,
+        ControlOperations, IoFunctions, MetaOperations, StreamOperations, SymbolOperations,
+        VectorOperations,
     },
     rerrs::ErrorKind,
     rvals::{
@@ -1037,12 +1037,12 @@ fn number_module() -> BuiltInModule {
     let mut module = BuiltInModule::new("steel/numbers");
     module
         .register_native_fn_definition(numbers::ADD_PRIMITIVE_DEFINITION)
-        .register_value("f+", NumOperations::float_add())
+        .register_native_fn_definition(numbers::FLOAT_ADD_DEFINITION)
         .register_native_fn_definition(numbers::MULTIPLY_PRIMITIVE_DEFINITION)
         .register_native_fn_definition(numbers::DIVIDE_PRIMITIVE_DEFINITION)
         .register_native_fn_definition(numbers::SUBTRACT_PRIMITIVE_DEFINITION)
         .register_native_fn_definition(numbers::EVEN_DEFINITION)
-        .register_value("odd?", NumOperations::odd())
+        .register_native_fn_definition(numbers::ODD_DEFINITION)
         .register_native_fn_definition(numbers::ARITHMETIC_SHIFT_DEFINITION)
         .register_native_fn_definition(numbers::ABS_DEFINITION)
         .register_native_fn_definition(numbers::NANP_DEFINITION)

--- a/crates/steel-core/src/steel_vm/primitives.rs
+++ b/crates/steel-core/src/steel_vm/primitives.rs
@@ -1043,7 +1043,7 @@ fn number_module() -> BuiltInModule {
         .register_native_fn_definition(numbers::SUBTRACT_PRIMITIVE_DEFINITION)
         .register_value("even?", NumOperations::even())
         .register_value("odd?", NumOperations::odd())
-        .register_value("arithmetic-shift", NumOperations::arithmetic_shift())
+        .register_native_fn_definition(numbers::ARITHMETIC_SHIFT_DEFINITION)
         .register_native_fn_definition(numbers::ABS_DEFINITION)
         .register_native_fn_definition(numbers::NANP_DEFINITION)
         .register_native_fn_definition(numbers::ZEROP_DEFINITION)


### PR DESCRIPTION
I made all functions inside NumOperations use steel_derive macros instead. I then deleted the NumOperations struct and registered the functions. Also I moved the functions higher up in the file so that they are where the other function definitions are, above the preconditions.  Finally I added documentation to all the functions. 

Tests returned successfully. 

Notes: During my testing it seemed like Arity was not working. Setting Arity to variations of AtLeast and Exact did not affect how many inputs I could pass during run time. 