### PR TITLE
check for char equality in `eqv?` and `eq?`

### DIFF
--- a/crates/steel-core/src/rvals.rs
+++ b/crates/steel-core/src/rvals.rs
@@ -1754,6 +1754,7 @@ impl SteelVal {
             (IntV(l), IntV(r)) => l == r,
             (NumV(l), NumV(r)) => l == r,
             (BoolV(l), BoolV(r)) => l == r,
+            (CharV(l), CharV(r)) => l == r,
             (VectorV(l), VectorV(r)) => Gc::ptr_eq(&l.0, &r.0),
             (Void, Void) => true,
             (StringV(l), StringV(r)) => crate::gc::Shared::ptr_eq(l, r),


### PR DESCRIPTION
in section "6.1. Equivalence predicates" of [r7rs](https://standards.scheme.org/official/r7rs.pdf) it states:

The `eqv?` procedure returns `#t` if:
- [ ... ]
- *obj1* and *obj2* are both characters and are the same
character according to the `char=?` procedure.

slightly surprising may also be, that `eqv?` and `eq?` do the same thing, though it is not in violation of the scheme r7rs standard, which explicitly specifies, that `eq?` *may* return `#f` in some cases where `eqv?` returns `#t`.

this was previously not true about steel, but this fixes that.

before:
![image](https://github.com/user-attachments/assets/34c400eb-61f4-4c0e-8397-268f805eeead)

after:
![image](https://github.com/user-attachments/assets/82f00edd-c723-47b1-9afa-477549328248)

