### PR TITLE
implement `symbol=?` and fix symbol equality for `eqv?` and `eq?`

### DIFF
--- a/crates/steel-core/src/primitives.rs
+++ b/crates/steel-core/src/primitives.rs
@@ -58,7 +58,7 @@ use std::convert::TryFrom;
 use std::result;
 pub use streams::StreamOperations;
 pub use strings::string_module;
-pub use symbols::SymbolOperations;
+pub use symbols::symbol_module;
 pub use vectors::VectorOperations;
 
 macro_rules! try_from_impl {

--- a/crates/steel-core/src/steel_vm/primitives.rs
+++ b/crates/steel-core/src/steel_vm/primitives.rs
@@ -30,7 +30,7 @@ use crate::{
         ports::{port_module_without_filesystem, EOF_OBJECTP_DEFINITION},
         process::process_module,
         random::random_module,
-        string_module,
+        string_module, symbol_module,
         tcp::tcp_module,
         time::time_module,
         vectors::{
@@ -41,8 +41,7 @@ use crate::{
             MUT_VEC_LENGTH_DEFINITION, MUT_VEC_SET_DEFINITION, MUT_VEC_TO_LIST_DEFINITION,
             VECTOR_FILL_DEFINITION, VEC_LENGTH_DEFINITION,
         },
-        ControlOperations, IoFunctions, MetaOperations, StreamOperations, SymbolOperations,
-        VectorOperations,
+        ControlOperations, IoFunctions, MetaOperations, StreamOperations, VectorOperations,
     },
     rerrs::ErrorKind,
     rvals::{
@@ -1300,14 +1299,6 @@ pub fn transducer_module() -> BuiltInModule {
         .register_value("into-for-each", crate::values::transducers::FOR_EACH)
         .register_value("into-nth", crate::values::transducers::NTH)
         .register_value("into-reducer", crate::values::transducers::REDUCER);
-    module
-}
-
-fn symbol_module() -> BuiltInModule {
-    let mut module = BuiltInModule::new("steel/symbols");
-    module
-        .register_value("concat-symbols", SymbolOperations::concat_symbols())
-        .register_value("symbol->string", SymbolOperations::symbol_to_string());
     module
 }
 


### PR DESCRIPTION
implement the `symbol=?` procedure as specified in section "6.5 Symbols" of [r7rs](https://standards.scheme.org/official/r7rs.pdf), where it says "all symbols have the same names in the sense of `string=?`", so i just implemented them by simply implementing string equality for the symbols.

in section "6.1. Equivalence predicates" it states, for both `eqv?`:
> The `eqv?` procedure returns `#t` if:
>
> - [ ... ]
> - *obj1* and *obj2* are both symbols and are the same symbol according to the `symbol=?` procedure (section 6.5).

and for `eq?`:
> On symbols, [ ... ], `eq?` and `eqv?` are guaranteed to have the same behavior.