### PR TITLE
steel-language-server: support renaming variables

### DIFF
--- a/crates/steel-core/src/compiler/passes/analysis.rs
+++ b/crates/steel-core/src/compiler/passes/analysis.rs
@@ -5757,6 +5757,35 @@ mod analysis_pass_tests {
     }
 
     #[test]
+    fn resolve_reference() {
+        let script = r#"
+            (define (double number)
+                (+ number number))
+        "#;
+
+        let mut exprs = Parser::parse(script).unwrap();
+        let analysis = SemanticAnalysis::new(&mut exprs);
+
+        let identifiers = analysis
+            .analysis
+            .identifier_info()
+            .iter()
+            .filter(|(_, semantic_info)| semantic_info.kind == IdentifierStatus::Local)
+            .map(|(id, _)| analysis.resolve_reference(*id))
+            .collect::<Vec<_>>();
+
+        assert_eq!(identifiers.len(), 3);
+
+        for window in identifiers.windows(2) {
+            let [left, right] = window else {
+                unreachable!()
+            };
+
+            assert_eq!(left, right);
+        }
+    }
+
+    #[test]
     fn test_capture() {
         let script = r#"
 

--- a/crates/steel-core/src/compiler/passes/analysis.rs
+++ b/crates/steel-core/src/compiler/passes/analysis.rs
@@ -470,6 +470,14 @@ impl Analysis {
         Some(id)
     }
 
+    pub fn resolve_reference(&self, mut id: SyntaxObjectId) -> SyntaxObjectId {
+        while let Some(next) = self.info.get(&id).and_then(|x| x.refers_to) {
+            id = next;
+        }
+
+        id
+    }
+
     pub fn visit_top_level_define_function_without_body(
         &mut self,
         define: &crate::parser::ast::Define,
@@ -4816,6 +4824,10 @@ impl<'a> SemanticAnalysis<'a> {
 
     pub fn resolve_alias(&self, id: SyntaxObjectId) -> Option<SyntaxObjectId> {
         self.analysis.resolve_alias(id)
+    }
+
+    pub fn resolve_reference(&self, id: SyntaxObjectId) -> SyntaxObjectId {
+        self.analysis.resolve_reference(id)
     }
 
     pub fn flatten_anonymous_functions(&mut self) {

--- a/crates/steel-language-server/src/main.rs
+++ b/crates/steel-language-server/src/main.rs
@@ -75,6 +75,7 @@ async fn main() {
     let (service, socket) = LspService::build(|client| Backend {
         client,
         ast_map: DashMap::new(),
+        lowered_ast_map: DashMap::new(),
         document_map: DashMap::new(),
         _macro_map: DashMap::new(),
         globals_set,


### PR DESCRIPTION
support the `textDocument/rename` and `textDocument/prepareRename` lsp requests. currently only works for `LetVar` and `Local` identifiers, as i was unsure of how to properly handle `Global` identifiers with regards to `(require ...)` and those two were the easiest to implement by far.

on an unrelated side note: i noticed that `(map ...)` is not marked as a builtin, which i think it should be?. not sure how to fix that though.