### PR TITLE
steel-language-server: disable markdown feature and fix doc extraction

### DIFF
--- a/crates/steel-language-server/Cargo.toml
+++ b/crates/steel-language-server/Cargo.toml
@@ -14,5 +14,5 @@ tower-lsp = { version = "0.20.0", features = ["proposed"] }
 serde = { version = "1.0.152", features = ["derive"] }
 dashmap = "5.1.0"
 log = "0.4.17"
-steel-core = { path = "../steel-core", version = "0.6.0", features = ["dylibs", "markdown", "stacker", "sync", "anyhow"] }
+steel-core = { path = "../steel-core", version = "0.6.0", features = ["dylibs", "stacker", "sync", "anyhow"] }
 once_cell = "1.18.0"

--- a/crates/steel-parser/src/parser.rs
+++ b/crates/steel-parser/src/parser.rs
@@ -1134,7 +1134,11 @@ impl<'a> Parser<'a> {
 
                         // println!("Collecting line: {}", doc_line);
 
-                        self.comment_buffer.push(doc_line.trim_start());
+                        let line = doc_line
+                            .strip_prefix(" ")
+                            .unwrap_or(doc_line)
+                            .trim_end_matches(['\n', '\r']);
+                        self.comment_buffer.push(line);
                     }
 
                     continue;


### PR DESCRIPTION
this fixes two seperate, but slightly related issues:

1. the steel-language-server depended on `steel-core` with the `markdown` feature enabled, causing the builtin docs to be rendered, instead of being passed along as the raw markdown.

i'm not super happy with this being dependant on a feature instead of there being a seperate function to collect the docs as just strings, but i didn't want to duplicate that much code for something that is already fairly trivially possible, so i just left it.

2. when collecting doc comment lines, steel previously trimmed all whitespace at the start. this caused code blocks with indentation to break, as the indentation was stripped as well. additionally steel did not attempt to trim the trailing newlines, and then later joined all the comment lines with a "\n", resulting in the newlines getting duplicated.

before:
![image](https://github.com/user-attachments/assets/7e814e61-9210-4d55-9c0b-f3f083396740)
![image](https://github.com/user-attachments/assets/558bb73e-1ca0-47c5-bfc7-fcc1bc0c7a52)

after:
![image](https://github.com/user-attachments/assets/1033ddd1-dff6-4d7d-bfb1-a002c4e7d215)
![image](https://github.com/user-attachments/assets/512eb445-767d-4f31-9487-9ed46dccfb49)
