### PR TITLE
parse more valid numbers

### DIFF
--- a/crates/steel-core/src/rvals.rs
+++ b/crates/steel-core/src/rvals.rs
@@ -1356,6 +1356,14 @@ impl SteelComplex {
             _ => unreachable!(),
         }
     }
+
+    fn imaginary_is_finite(&self) -> bool {
+        match &self.im {
+            NumV(x) => x.is_finite(),
+            IntV(_) | Rational(_) | BigNum(_) | SteelVal::BigRational(_) => true,
+            _ => unreachable!(),
+        }
+    }
 }
 
 impl IntoSteelVal for SteelComplex {
@@ -1371,7 +1379,7 @@ impl IntoSteelVal for SteelComplex {
 
 impl fmt::Display for SteelComplex {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if self.imaginary_is_negative() {
+        if self.imaginary_is_negative() || !self.imaginary_is_finite() {
             write!(f, "{re}{im}i", re = self.re, im = self.im)
         } else {
             write!(f, "{re}+{im}i", re = self.re, im = self.im)

--- a/crates/steel-parser/src/lexer.rs
+++ b/crates/steel-parser/src/lexer.rs
@@ -1222,7 +1222,7 @@ mod lexer_tests {
     #[test]
     fn test_real_numbers() {
         let got: Vec<_> = TokenStream::new(
-            "0 -0 -1.2 +2.3 999 1. 1e2 1E2 1.2e2 1.2E2 +inf.0 -inf.0",
+            "0 -0 -1.2 +2.3 999 1. 1e2 1E2 1.2e2 1.2E2 +inf.0 -inf.0 2e-4 2e+10",
             true,
             SourceId::none(),
         )
@@ -1290,6 +1290,16 @@ mod lexer_tests {
                     source: "-inf.0",
                     span: Span::new(49, 55, SourceId::none()),
                 },
+                Token {
+                    ty: RealLiteral::Float(2e-4).into(),
+                    source: "2e-4",
+                    span: Span::new(56, 60, SourceId::none()),
+                },
+                Token {
+                    ty: RealLiteral::Float(2e+10).into(),
+                    source: "2e+10",
+                    span: Span::new(61, 66, SourceId::none())
+                }
             ]
         );
     }
@@ -1416,7 +1426,7 @@ mod lexer_tests {
     #[test]
     fn test_complex_numbers() {
         let got: Vec<_> = TokenStream::new(
-            "1+2i 3-4i +5+6i +1i 1.0+2.0i 3-4.0i +1.0i",
+            "1+2i 3-4i +5+6i +1i 1.0+2.0i 3-4.0i +1.0i 2e+4+inf.0i -inf.0i-2e-4",
             true,
             SourceId::none(),
         )
@@ -1487,6 +1497,24 @@ mod lexer_tests {
                     source: "+1.0i",
                     span: Span::new(36, 41, SourceId::none()),
                 },
+                Token {
+                    ty: NumberLiteral::Complex(
+                        RealLiteral::Float(2e+4),
+                        RealLiteral::Float(f64::INFINITY),
+                    )
+                    .into(),
+                    source: "2e+4+inf.0i",
+                    span: Span::new(42, 53, SourceId::none()),
+                },
+                Token {
+                    ty: NumberLiteral::Complex(
+                        RealLiteral::Float(-2e-4),
+                        RealLiteral::Float(f64::NEG_INFINITY)
+                    )
+                    .into(),
+                    source: "-inf.0i-2e-4",
+                    span: Span::new(54, 66, SourceId::none()),
+                }
             ]
         );
     }

--- a/crates/steel-parser/src/lexer.rs
+++ b/crates/steel-parser/src/lexer.rs
@@ -868,8 +868,7 @@ fn parse_number(s: &str) -> Option<NumberLiteral> {
             };
             Some(NumberLiteral::Complex(IntLiteral::Small(0).into(), parse_real(x)?).into())
         }
-        [NumPart::Real(re), NumPart::Imaginary(im)]
-        | [NumPart::Imaginary(im), NumPart::Real(re)] => {
+        [NumPart::Real(re), NumPart::Imaginary(im)] => {
             Some(NumberLiteral::Complex(parse_real(re)?, parse_real(im)?))
         }
         _ => None,
@@ -1426,7 +1425,7 @@ mod lexer_tests {
     #[test]
     fn test_complex_numbers() {
         let got: Vec<_> = TokenStream::new(
-            "1+2i 3-4i +5+6i +1i 1.0+2.0i 3-4.0i +1.0i 2e+4+inf.0i -inf.0i-2e-4",
+            "1+2i 3-4i +5+6i +1i 1.0+2.0i 3-4.0i +1.0i 2e+4+inf.0i -inf.0-2e-4i",
             true,
             SourceId::none(),
         )
@@ -1508,11 +1507,11 @@ mod lexer_tests {
                 },
                 Token {
                     ty: NumberLiteral::Complex(
+                        RealLiteral::Float(f64::NEG_INFINITY),
                         RealLiteral::Float(-2e-4),
-                        RealLiteral::Float(f64::NEG_INFINITY)
                     )
                     .into(),
-                    source: "-inf.0i-2e-4",
+                    source: "-inf.0-2e-4i",
                     span: Span::new(54, 66, SourceId::none()),
                 }
             ]

--- a/crates/steel-parser/src/tokens.rs
+++ b/crates/steel-parser/src/tokens.rs
@@ -118,7 +118,7 @@ impl Display for NumberLiteral {
         match self {
             NumberLiteral::Real(r) => r.fmt(f),
             NumberLiteral::Complex(re, im) => {
-                if im.is_negative() {
+                if im.is_negative() || !im.is_finite() {
                     write!(f, "{re}{im}i")
                 } else {
                     write!(f, "{re}+{im}i")
@@ -147,6 +147,14 @@ impl RealLiteral {
             RealLiteral::Int(i) => i.is_negative(),
             RealLiteral::Rational(n, _) => n.is_negative(),
             RealLiteral::Float(f) => f.is_sign_negative(),
+        }
+    }
+
+    fn is_finite(&self) -> bool {
+        match self {
+            RealLiteral::Int(_) => true,
+            RealLiteral::Rational(_, _) => true,
+            RealLiteral::Float(f) => f.is_finite(),
         }
     }
 }


### PR DESCRIPTION
there were a few numbers that were valid in scheme, but were not being parsed correctly by steel. i initally noticed this when i wanted to type `2e-4`, but that didn't work.

an incomplete list of numbers that are now supported:
- `2e-4` (which evaluates to `0.0002`)
- `2e+4` (which evaluates to `20000`)
- `3.0+inf.0i`
- `2e+4+inf.0i` (which evaluates to `20000+inf.0i`)
- `-inf.0i-2e-4` (which evaluates to `-0.0002-inf.0i`)
- `+nan.0+5.0i`
- `+inf.0+nan.0i`

![image](https://github.com/user-attachments/assets/09e0d2ee-9e7f-4ae3-8500-1faa232f6791)