### PR TITLE
implement `real-part` and `imag-part` procedures

### DIFF
--- a/crates/steel-core/src/primitives/numbers.rs
+++ b/crates/steel-core/src/primitives/numbers.rs
@@ -1239,6 +1239,50 @@ fn sqrt(number: &SteelVal) -> Result<SteelVal> {
     }
 }
 
+/// Returns the real part of a number
+///
+/// (real-part number) -> number?
+///
+/// # Examples
+/// ```scheme
+/// > (real-part 3+4i) ;; => 3
+/// > (real-part 42) ;; => 42
+/// ```
+#[steel_derive::function(name = "real-part", constant = true)]
+pub fn real_part(value: &SteelVal) -> Result<SteelVal> {
+    match value {
+        val @ SteelVal::IntV(_)
+        | val @ SteelVal::BigNum(_)
+        | val @ SteelVal::Rational(_)
+        | val @ SteelVal::BigRational(_)
+        | val @ SteelVal::NumV(_) => Ok(val.clone()),
+        SteelVal::Complex(complex) => Ok(complex.re.clone()),
+        _ => steelerr!(TypeMismatch => "real-part expected number"),
+    }
+}
+
+/// Returns the imaginary part of a number
+///
+/// (imag-part number) -> number?
+///
+/// # Examples
+/// ```scheme
+/// > (imag-part 3+4i) ;; => 4
+/// > (imag-part 42) ;; => 0
+/// ```
+#[steel_derive::function(name = "imag-part", constant = true)]
+pub fn imag_part(value: &SteelVal) -> Result<SteelVal> {
+    match value {
+        SteelVal::IntV(_)
+        | SteelVal::BigNum(_)
+        | SteelVal::Rational(_)
+        | SteelVal::BigRational(_)
+        | SteelVal::NumV(_) => Ok(SteelVal::IntV(0)),
+        SteelVal::Complex(complex) => Ok(complex.im.clone()),
+        _ => steelerr!(TypeMismatch => "imag-part expected number"),
+    }
+}
+
 /// Computes the magnitude of the given number.
 ///
 /// (magnitude number) -> number?

--- a/crates/steel-core/src/steel_vm/primitives.rs
+++ b/crates/steel-core/src/steel_vm/primitives.rs
@@ -1063,6 +1063,8 @@ fn number_module() -> BuiltInModule {
         .register_native_fn_definition(numbers::INFINITEP_DEFINITION)
         .register_native_fn_definition(numbers::LOG_DEFINITION)
         .register_native_fn_definition(numbers::MAGNITUDE_DEFINITION)
+        .register_native_fn_definition(numbers::REAL_PART_DEFINITION)
+        .register_native_fn_definition(numbers::IMAG_PART_DEFINITION)
         .register_native_fn_definition(numbers::NUMERATOR_DEFINITION)
         .register_native_fn_definition(numbers::QUOTIENT_DEFINITION)
         .register_native_fn_definition(numbers::MODULO_DEFINITION)

--- a/crates/steel-core/src/tests/success/numbers.scm
+++ b/crates/steel-core/src/tests/success/numbers.scm
@@ -169,6 +169,11 @@
 (assert-equal! 10.0 (magnitude -10.0))
 (assert-equal! 5 (magnitude -3+4i))
 
+(assert-equal! 3 (real-part 3+4i))
+(assert-equal! 42 (real-part 42))
+(assert-equal! 4 (imag-part 3+4i))
+(assert-equal! 0 (imag-part 42))
+
 (assert-equal! 10.0 (ceiling 9.1))
 (assert-equal! 9.0 (floor 9.1))
 (assert-equal! 10.0 (ceiling 10.0))

--- a/docs/src/builtins/steel_base.md
+++ b/docs/src/builtins/steel_base.md
@@ -1173,6 +1173,35 @@ Computes the natural logarithm of the given number.
 > (log 100 10) ;; => 2
 > (log 27 3) ;; => 3
 ```
+
+### **real-part**
+
+Returns the real part of a number
+
+(real-part number) -> number?
+
+* number: number? - The numbers to get the real part of.
+
+#### Examples
+```scheme
+> (real-part 3+4i) ;; => 3
+> (real-part 42) ;; => 42
+```
+
+### **imag-part**
+
+Returns the imaginary part of a number
+
+(imag-part number) -> number?
+
+* number: number? - The numbers to get the imaginary part of.
+
+# Examples
+```scheme
+> (imag-part 3+4i) ;; => 4
+> (imag-part 42) ;; => 0
+```
+
 ### **magnitude**
 Computes the magnitude of the given number.
 

--- a/docs/src/builtins/steel_numbers.md
+++ b/docs/src/builtins/steel_numbers.md
@@ -304,6 +304,35 @@ Computes the natural logarithm of the given number.
 > (log 100 10) ;; => 2
 > (log 27 3) ;; => 3
 ```
+
+### **real-part**
+
+Returns the real part of a number
+
+(real-part number) -> number?
+
+* number: number? - The numbers to get the real part of.
+
+#### Examples
+```scheme
+> (real-part 3+4i) ;; => 3
+> (real-part 42) ;; => 42
+```
+
+### **imag-part**
+
+Returns the imaginary part of a number
+
+(imag-part number) -> number?
+
+* number: number? - The numbers to get the real part of.
+
+# Examples
+```scheme
+> (imag-part 3+4i) ;; => 4
+> (imag-part 42) ;; => 0
+```
+
 ### **magnitude**
 Computes the magnitude of the given number.
 


### PR DESCRIPTION
implements the `real-part` and `imag-part` procedures, defined in [r7rs](https://standards.scheme.org/official/r7rs.pdf) chapter "6.2.6. Numerical operations", on page 39.