### PR TITLE
Copy macro environment on write

### DIFF
--- a/crates/steel-core/src/compiler/constants.rs
+++ b/crates/steel-core/src/compiler/constants.rs
@@ -56,8 +56,10 @@ impl ConstantMap {
     }
 
     pub fn flush(&self) {
-        let values = self.values.read().clone();
-        self.reified_values.store(Arc::new(values));
+        let values = self.values.read();
+        if values.len() != self.reified_values.load().len() {
+            self.reified_values.store(Arc::new(values.clone()));
+        }
     }
 
     pub fn deep_clone(&self) -> ConstantMap {

--- a/crates/steel-core/src/compiler/passes/analysis.rs
+++ b/crates/steel-core/src/compiler/passes/analysis.rs
@@ -3987,7 +3987,7 @@ impl<'a> SemanticAnalysis<'a> {
         }
 
         for module in module_manager.modules_mut() {
-            for steel_macro in module.1.macro_map.values_mut() {
+            for steel_macro in std::sync::Arc::make_mut(&mut module.1.macro_map).values_mut() {
                 if !steel_macro.is_mangled() {
                     for expr in steel_macro.exprs_mut() {
                         macro_replacer.visit(expr);


### PR DESCRIPTION
There were some regressions in compilation time, mostly due to changes for the constant map and the default global macros. Now we're doing some copy on write which seems to shave off about 1 ms from the compilation time.