### PR TITLE
better parsing of numbers with radixes

### DIFF
--- a/crates/steel-parser/src/lexer.rs
+++ b/crates/steel-parser/src/lexer.rs
@@ -1518,6 +1518,69 @@ mod lexer_tests {
     }
 
     #[test]
+    fn test_numbers_with_radix() {
+        let got = TokenStream::new(
+            "#xff #xce #o777 #o1/20 #b1/10 #x10+ffi #d1.0",
+            true,
+            SourceId::none(),
+        )
+        .collect::<Vec<_>>();
+
+        assert_eq!(
+            &*got,
+            &[
+                Token {
+                    ty: NumberLiteral::Real(IntLiteral::Small(255).into()).into(),
+                    source: "#xff",
+                    span: Span::new(0, 4, SourceId::none()),
+                },
+                Token {
+                    ty: NumberLiteral::Real(IntLiteral::Small(206).into()).into(),
+                    source: "#xce",
+                    span: Span::new(5, 9, SourceId::none()),
+                },
+                Token {
+                    ty: NumberLiteral::Real(IntLiteral::Small(511).into()).into(),
+                    source: "#o777",
+                    span: Span::new(10, 15, SourceId::none()),
+                },
+                Token {
+                    ty: NumberLiteral::Real(RealLiteral::Rational(
+                        IntLiteral::Small(1),
+                        IntLiteral::Small(16)
+                    ))
+                    .into(),
+                    source: "#o1/20",
+                    span: Span::new(16, 22, SourceId::none()),
+                },
+                Token {
+                    ty: NumberLiteral::Real(RealLiteral::Rational(
+                        IntLiteral::Small(1),
+                        IntLiteral::Small(2)
+                    ))
+                    .into(),
+                    source: "#b1/10",
+                    span: Span::new(23, 29, SourceId::none()),
+                },
+                Token {
+                    ty: NumberLiteral::Complex(
+                        IntLiteral::Small(16).into(),
+                        IntLiteral::Small(255).into(),
+                    )
+                    .into(),
+                    source: "#x10+ffi",
+                    span: Span::new(30, 38, SourceId::none()),
+                },
+                Token {
+                    ty: NumberLiteral::Real(RealLiteral::Float(1.0)).into(),
+                    source: "#d1.0",
+                    span: Span::new(39, 44, SourceId::none()),
+                }
+            ]
+        );
+    }
+
+    #[test]
     fn test_malformed_complex_numbers_are_identifiers() {
         let got: Vec<_> =
             TokenStream::new("i -i 1i+1i 4+i -4+-2i", true, SourceId::none()).collect();

--- a/crates/steel-parser/src/lexer.rs
+++ b/crates/steel-parser/src/lexer.rs
@@ -728,7 +728,7 @@ impl<'a> Iterator for Lexer<'a> {
                 let next = self.chars.peek().copied();
 
                 let token = match next {
-                    Some('x' | 'd' | 'o' | 'b') => {
+                    Some('x' | 'X' | 'd' | 'D' | 'o' | 'O' | 'b' | 'B') => {
                         self.eat();
                         self.read_number()
                     }
@@ -858,10 +858,10 @@ fn parse_real(s: &str, radix: Option<u32>) -> Option<RealLiteral> {
 
 fn parse_number(s: &str) -> Option<NumberLiteral> {
     let (s, radix) = match s.get(0..2) {
-        Some("#x") => (&s[2..], Some(16)),
-        Some("#d") => (&s[2..], Some(10)),
-        Some("#o") => (&s[2..], Some(8)),
-        Some("#b") => (&s[2..], Some(2)),
+        Some("#x" | "#X") => (&s[2..], Some(16)),
+        Some("#d" | "#D") => (&s[2..], Some(10)),
+        Some("#o" | "#O") => (&s[2..], Some(8)),
+        Some("#b" | "#B") => (&s[2..], Some(2)),
         _ => (s, None),
     };
 

--- a/crates/steel-parser/src/lexer.rs
+++ b/crates/steel-parser/src/lexer.rs
@@ -803,16 +803,16 @@ fn parse_real(s: &str, radix: u32) -> Option<RealLiteral> {
         return Some(RealLiteral::Float(f64::NAN));
     }
 
-    let mut has_e = false;
     let mut has_dot = false;
+    let mut has_exponent = false;
     let mut frac_position = None;
     for (idx, ch) in s.chars().enumerate() {
         match ch {
-            'e' | 'E' => {
-                if has_e {
+            'e' | 'E' if radix < 15 => {
+                if has_exponent {
                     return None;
                 };
-                has_e = true;
+                has_exponent = true;
             }
             '/' => {
                 frac_position = match frac_position {
@@ -830,7 +830,7 @@ fn parse_real(s: &str, radix: u32) -> Option<RealLiteral> {
         }
     }
 
-    if has_e || has_dot {
+    if has_exponent || has_dot {
         if radix != 10 {
             // radix for floating points not yet supported
             return None;

--- a/crates/steel-parser/src/tokens.rs
+++ b/crates/steel-parser/src/tokens.rs
@@ -2,7 +2,8 @@ use crate::lexer;
 use crate::parser::SourceId;
 use crate::span::Span;
 use core::ops;
-use num::{BigInt, Rational32, Signed};
+use num::bigint::ParseBigIntError;
+use num::{BigInt, Num, Rational32, Signed};
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::fmt::{self, Display};
@@ -219,6 +220,16 @@ pub enum IntLiteral {
 }
 
 impl IntLiteral {
+    pub fn from_str_radix(src: &str, radix: u32) -> Result<IntLiteral, ParseBigIntError> {
+        isize::from_str_radix(src, radix)
+            .map(IntLiteral::Small)
+            .or_else(|_| {
+                BigInt::from_str_radix(src, radix)
+                    .map(Box::new)
+                    .map(IntLiteral::Big)
+            })
+    }
+
     fn is_negative(&self) -> bool {
         match self {
             IntLiteral::Small(i) => i.is_negative(),


### PR DESCRIPTION
move radix parsing into the `parse_number` function in the lexer instead of handling it seperately. this makes it a lot easier to implement for example complex numbers and fractionals with radixes.

i couldn't find a way to parse floats with radixes, the closest i could get was the [lexical crate](https://crates.io/crates/lexical), but that only supports passing the number format as const generics if i'm not mistaken. i'll look another time, but for now they just aren't supported.

before:
![image](https://github.com/user-attachments/assets/d7857334-929f-44fd-8a3e-0b4ce246fc66)

after:
![image](https://github.com/user-attachments/assets/deef8ce4-c480-4113-96c5-647c1937d5a5)
