### PR TITLE
allow range builtin to be called with only one argument

### DIFF
--- a/crates/steel-core/src/primitives/lists.rs
+++ b/crates/steel-core/src/primitives/lists.rs
@@ -947,9 +947,17 @@ mod list_operation_tests {
 
     #[test]
     fn range_tests_arity_too_few() {
-        let args = [SteelVal::IntV(1)];
-        let res = steel_range(&args);
+        let args = [];
+        let res = range(&args);
         let expected = ErrorKind::ArityMismatch;
+        assert_eq!(res.unwrap_err().kind(), expected);
+    }
+
+    #[test]
+    fn range_tests_type_mismatch() {
+        let args = [SteelVal::StringV("test".into()), SteelVal::IntV(1)];
+        let res = range(&args);
+        let expected = ErrorKind::TypeMismatch;
         assert_eq!(res.unwrap_err().kind(), expected);
     }
 
@@ -960,17 +968,25 @@ mod list_operation_tests {
             SteelVal::NumV(2.0),
             SteelVal::NumV(3.0),
         ];
-        let res = steel_range(&args);
+        let res = range(&args);
         let expected = ErrorKind::ArityMismatch;
         assert_eq!(res.unwrap_err().kind(), expected);
     }
 
     #[test]
+    fn range_tests_single_element() {
+        let args = [SteelVal::IntV(2)];
+        let res = range(&args);
+        let expected = SteelVal::ListV(vec![SteelVal::IntV(0), SteelVal::IntV(1)].into());
+        assert_eq!(res.unwrap(), expected);
+    }
+
+    #[test]
     fn range_test_normal_input() {
-        let args = [SteelVal::IntV(0), SteelVal::IntV(3)];
-        let res = steel_range(&args);
+        let args = [SteelVal::IntV(2), SteelVal::IntV(5)];
+        let res = range(&args);
         let expected =
-            SteelVal::ListV(vec![SteelVal::IntV(0), SteelVal::IntV(1), SteelVal::IntV(2)].into());
+            SteelVal::ListV(vec![SteelVal::IntV(2), SteelVal::IntV(3), SteelVal::IntV(4)].into());
         assert_eq!(res.unwrap(), expected);
     }
 }

--- a/docs/src/builtins/steel_base.md
+++ b/docs/src/builtins/steel_base.md
@@ -1775,15 +1775,17 @@ Returns quotient of dividing numerator by denomintator.
 > (quotient -10 2) ;; => -5
 ```
 ### **range**
-Returns a newly allocated list of the elements in the range (n, m]
+Returns a newly allocated list of the elements in the range [n, m) or [0, m) when n is not given.
 
+(range m)   -> (listof int?)
 (range n m) -> (listof int?)
 
 * n : int?
 * m : int?
 
 ```scheme
-> (range 0 10) ;; => '(0 1 2 3 4 5 6 7 8 9)
+> (range 4) ;; => '(0 1 2 3)
+> (range 4 10) ;; => '(4 5 6 7 8 9)
 ```
 ### **range-vec**
 Constructs a vector containing a range of integers from `start` to `end` (exclusive).

--- a/docs/src/builtins/steel_lists.md
+++ b/docs/src/builtins/steel_lists.md
@@ -177,15 +177,17 @@ Checks if the given value can be treated as a pair.
 > (pair? '()) ;; => #false
 ```
 ### **range**
-Returns a newly allocated list of the elements in the range (n, m]
+Returns a newly allocated list of the elements in the range [n, m) or [0, m) when n is not given.
 
+(range m)   -> (listof int?)
 (range n m) -> (listof int?)
 
 * n : int?
 * m : int?
 
 ```scheme
-> (range 0 10) ;; => '(0 1 2 3 4 5 6 7 8 9)
+> (range 4) ;; => '(0 1 2 3)
+> (range 4 10) ;; => '(4 5 6 7 8 9)
 ```
 ### **rest**
 Returns the rest of the list. Will raise an error if the list is empty.


### PR DESCRIPTION
allow the `(range)` function to only take 1 argument. this makes it a `0..m` range. this also fixes the docs, as they confused the `(` and `[` brackets (i think lol).

i was not sure how to document functions that take one or two arguments, so i took inspiration from racket and documented both options seperately.

i was also not sure which arity to use, as `Range(n)` only takes one number and i would need a `Range(1, 2)` (i think), so i just picked `AtMost(2)`.