### PR TITLE
improve transducers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2520,9 +2520,9 @@ checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "plist"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42cf17e9a1800f5f396bc67d193dc9411b59012a5876445ef450d449881e1016"
+checksum = "eac26e981c03a6e53e0aee43c113e3202f5581d5360dae7bd2c70e800dd0451d"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.7.1",

--- a/crates/steel-core/src/primitives/lists.rs
+++ b/crates/steel-core/src/primitives/lists.rs
@@ -76,7 +76,6 @@ pub fn list_module() -> BuiltInModule {
         .register_value("push-back", crate::primitives::lists::PUSH_BACK)
         .register_native_fn_definition(PAIR_DEFINITION)
         .register_native_fn_definition(APPLY_DEFINITION)
-        .register_value("transduce", crate::steel_vm::transducers::TRANSDUCE)
         .register_native_fn_definition(SECOND_DEFINITION)
         .register_native_fn_definition(THIRD_DEFINITION)
         .register_native_fn_definition(TAKE_DEFINITION)

--- a/crates/steel-core/src/primitives/transducers.rs
+++ b/crates/steel-core/src/primitives/transducers.rs
@@ -26,11 +26,11 @@ pub fn transducer_module() -> BuiltInModule {
 
     module
         .register_native_fn_definition(COMPOSE_DEFINITION)
-        .register_native_fn_definition(MAP_DEFINITION)
-        .register_native_fn_definition(FLATTEN_DEFINITION)
-        .register_native_fn_definition(FLAT_MAP_DEFINITION)
-        .register_native_fn_definition(FILTER_DEFINITION)
-        .register_native_fn_definition(TAKE_DEFINITION)
+        .register_native_fn_definition(MAPPING_DEFINITION)
+        .register_native_fn_definition(FLATTENING_DEFINITION)
+        .register_native_fn_definition(FLAT_MAPPING_DEFINITION)
+        .register_native_fn_definition(FILTERING_DEFINITION)
+        .register_native_fn_definition(TAKING_DEFINITION)
         .register_native_fn_definition(DROPPING_DEFINITION)
         .register_native_fn_definition(EXTENDING_DEFINITION)
         .register_native_fn_definition(ENUMERATING_DEFINITION)
@@ -103,7 +103,7 @@ pub fn interleaving(iterable: &SteelVal) -> Result<SteelVal> {
 }
 
 #[steel_derive::function(name = "mapping")]
-pub fn map(func: &SteelVal) -> Result<SteelVal> {
+pub fn mapping(func: &SteelVal) -> Result<SteelVal> {
     match &func {
         Closure(_) | FuncV(_) | BoxedFunction(_) | BuiltIn(_) | MutFunc(_) => {
             let mut transducer = Transducer::new();
@@ -129,7 +129,7 @@ pub fn extending(iterable: &SteelVal) -> Result<SteelVal> {
 }
 
 #[steel_derive::function(name = "flat-mapping")]
-pub fn flat_map(func: &SteelVal) -> Result<SteelVal> {
+pub fn flat_mapping(func: &SteelVal) -> Result<SteelVal> {
     match &func {
         Closure(_) | FuncV(_) | BoxedFunction(_) | BuiltIn(_) | MutFunc(_) => {
             let mut transducer = Transducer::new();
@@ -143,14 +143,14 @@ pub fn flat_map(func: &SteelVal) -> Result<SteelVal> {
 }
 
 #[steel_derive::function(name = "flattening")]
-pub fn flatten() -> Result<SteelVal> {
+pub fn flattening() -> Result<SteelVal> {
     let mut transducer = Transducer::new();
     transducer.push(Transducers::Flatten);
     Ok(SteelVal::IterV(Gc::new(transducer)))
 }
 
 #[steel_derive::function(name = "filtering")]
-pub fn filter(func: &SteelVal) -> Result<SteelVal> {
+pub fn filtering(func: &SteelVal) -> Result<SteelVal> {
     match &func {
         Closure(_) | FuncV(_) | BoxedFunction(_) | BuiltIn(_) | MutFunc(_) => {
             let mut transducer = Transducer::new();
@@ -162,7 +162,7 @@ pub fn filter(func: &SteelVal) -> Result<SteelVal> {
 }
 
 #[steel_derive::function(name = "taking")]
-pub fn take(amt: &SteelVal) -> Result<SteelVal> {
+pub fn taking(amt: &SteelVal) -> Result<SteelVal> {
     if let IntV(_) = &amt {
         let mut transducer = Transducer::new();
         transducer.push(Transducers::Take(amt.clone()));

--- a/crates/steel-core/src/primitives/transducers.rs
+++ b/crates/steel-core/src/primitives/transducers.rs
@@ -53,6 +53,17 @@ pub fn transducer_module() -> BuiltInModule {
     module
 }
 
+/// Compose multiple iterators into one iterator
+///
+/// (compose . iters) -> iterator?
+///
+/// # Examples
+/// ```scheme
+/// (compose
+///     (mapping (λ (x) (+ x 1)))
+///     (filtering odd?)
+///     (taking 15))
+/// ```
 #[steel_derive::native(name = "compose", arity = "AtLeast(0)")]
 pub fn compose(args: &[SteelVal]) -> Result<SteelVal> {
     let mut transformers = Transducer::new();
@@ -67,6 +78,14 @@ pub fn compose(args: &[SteelVal]) -> Result<SteelVal> {
     Ok(SteelVal::IterV(Gc::new(transformers)))
 }
 
+/// Create an enumerating iterator
+///
+/// (enumerating) -> iterator?
+///
+/// # Examples
+/// ```scheme
+/// (transduce (list 1 3 5) (enumerating) (into-list)) ;; => '((0 1) (1 3) (2 5))
+/// ```
 #[steel_derive::function(name = "enumerating")]
 pub fn enumerating() -> Result<SteelVal> {
     let mut transducer = Transducer::new();
@@ -74,6 +93,14 @@ pub fn enumerating() -> Result<SteelVal> {
     Ok(SteelVal::IterV(Gc::new(transducer)))
 }
 
+/// Create a zipping iterator
+///
+/// (zipping any/c) -> iterator?
+///
+/// # Examples
+/// ```scheme
+/// (transduce (list 1 2 3) (zipping (list 4 5 6 7)) (into-list)) ;; => '((1 4) (2 5) (3 6))
+/// ```
 #[steel_derive::function(name = "zipping")]
 pub fn zipping(iterable: &SteelVal) -> Result<SteelVal> {
     match iterable {
@@ -88,6 +115,14 @@ pub fn zipping(iterable: &SteelVal) -> Result<SteelVal> {
     }
 }
 
+/// Create an interleaving iterator
+///
+/// (interleaving any/c) -> iterator?
+///
+/// # Examples
+/// ```scheme
+/// (transduce (list 1 2 3) (interleaving (list 4 5 6)) (into-list)) ;; => '(1 4 2 5 3 6)
+/// ```
 #[steel_derive::function(name = "interleaving")]
 pub fn interleaving(iterable: &SteelVal) -> Result<SteelVal> {
     match &iterable {
@@ -102,6 +137,14 @@ pub fn interleaving(iterable: &SteelVal) -> Result<SteelVal> {
     }
 }
 
+/// Create a mapping iterator
+///
+/// (mapping proc?) -> iterator?
+///
+/// # Examples
+/// ```scheme
+/// (transduce (list 1 2 3) (mapping (λ (x) (+ x 1))) (into-list)) ;; => '(2 3 4)
+/// ```
 #[steel_derive::function(name = "mapping")]
 pub fn mapping(func: &SteelVal) -> Result<SteelVal> {
     match &func {
@@ -114,6 +157,14 @@ pub fn mapping(func: &SteelVal) -> Result<SteelVal> {
     }
 }
 
+/// Create an extending iterator
+///
+/// (extending iterable) -> iterator?
+///
+/// # Examples
+/// ```scheme
+/// (transduce (list 1 2 3) (extending (list 4 5 6 7)) (into-list)) ;; => '(1 2 3 4 5 6 7)
+/// ```
 #[steel_derive::function(name = "extending")]
 pub fn extending(iterable: &SteelVal) -> Result<SteelVal> {
     match &iterable {
@@ -128,6 +179,14 @@ pub fn extending(iterable: &SteelVal) -> Result<SteelVal> {
     }
 }
 
+/// Creates a flat-mapping iterator
+///
+/// (flat-mapping proc?) -> iterator
+///
+/// # Examples
+/// ```scheme
+/// (transduce (list 1 2 3) (flat-mapping (λ (x) (range 0 x))) (into-list)) ;; => '(0 0 1 0 1 2)
+/// ```
 #[steel_derive::function(name = "flat-mapping")]
 pub fn flat_mapping(func: &SteelVal) -> Result<SteelVal> {
     match &func {
@@ -142,6 +201,14 @@ pub fn flat_mapping(func: &SteelVal) -> Result<SteelVal> {
     }
 }
 
+/// Creates a flattening iterator that etc
+///
+/// (flattening) -> iterator?
+///
+/// # Examples
+/// ```scheme
+/// (transduce (list '(1 2) '(3 4) '(5 6)) (flattening) (into-list)) ;; => '(1 2 3 4 5 6)
+/// ```
 #[steel_derive::function(name = "flattening")]
 pub fn flattening() -> Result<SteelVal> {
     let mut transducer = Transducer::new();
@@ -149,6 +216,14 @@ pub fn flattening() -> Result<SteelVal> {
     Ok(SteelVal::IterV(Gc::new(transducer)))
 }
 
+/// Creates a filtering iterator
+///
+/// (filtering proc?) -> iterator?
+///
+/// # Examples
+/// ```scheme
+/// (transduce (list 1 2 3 4) (filtering even?) (into-list)) ;; => '(2 4)
+/// ```
 #[steel_derive::function(name = "filtering")]
 pub fn filtering(func: &SteelVal) -> Result<SteelVal> {
     match &func {
@@ -161,6 +236,14 @@ pub fn filtering(func: &SteelVal) -> Result<SteelVal> {
     }
 }
 
+/// Creates a taking iterator combinator
+///
+/// (taking number?) -> iterator?
+///
+/// # Examples
+/// ```scheme
+/// (transduce (list 1 2 3 4 5) (taking 3) (into-list)) ;; => '(1 2 3)
+/// ```
 #[steel_derive::function(name = "taking")]
 pub fn taking(amt: &SteelVal) -> Result<SteelVal> {
     if let IntV(_) = &amt {
@@ -172,6 +255,14 @@ pub fn taking(amt: &SteelVal) -> Result<SteelVal> {
     }
 }
 
+/// Creates a taking iterator combinator
+///
+/// (dropping integer?) -> iterator?
+///
+/// # Examples
+/// ```scheme
+/// (transduce (list 1 2 3 4 5) (dropping 3) (into-list)) ;; => '(4 5)
+/// ```
 #[steel_derive::function(name = "dropping")]
 pub fn dropping(amt: &SteelVal) -> Result<SteelVal> {
     if let IntV(_) = amt {
@@ -182,4 +273,3 @@ pub fn dropping(amt: &SteelVal) -> Result<SteelVal> {
         stop!(TypeMismatch => "dropping expects an integer")
     }
 }
-// }

--- a/crates/steel-core/src/primitives/transducers.rs
+++ b/crates/steel-core/src/primitives/transducers.rs
@@ -1,6 +1,7 @@
 use crate::gc::Gc;
 use crate::rvals::SteelVal::*;
 use crate::rvals::{Result, SteelVal};
+use crate::steel_vm::builtin::BuiltInModule;
 use crate::stop;
 
 use crate::values::transducers::Transducer;
@@ -19,6 +20,38 @@ use crate::values::transducers::Transducers;
 //     TAKING => take,
 //     DROPPING => dropping,
 // );
+
+pub fn transducer_module() -> BuiltInModule {
+    let mut module = BuiltInModule::new("steel/transducers");
+
+    module
+        .register_native_fn_definition(COMPOSE_DEFINITION)
+        .register_native_fn_definition(MAP_DEFINITION)
+        .register_native_fn_definition(FLATTEN_DEFINITION)
+        .register_native_fn_definition(FLAT_MAP_DEFINITION)
+        .register_native_fn_definition(FILTER_DEFINITION)
+        .register_native_fn_definition(TAKE_DEFINITION)
+        .register_native_fn_definition(DROPPING_DEFINITION)
+        .register_native_fn_definition(EXTENDING_DEFINITION)
+        .register_native_fn_definition(ENUMERATING_DEFINITION)
+        .register_native_fn_definition(ZIPPING_DEFINITION)
+        .register_native_fn_definition(INTERLEAVING_DEFINITION)
+        .register_value("into-sum", crate::values::transducers::INTO_SUM)
+        .register_value("into-product", crate::values::transducers::INTO_PRODUCT)
+        .register_value("into-max", crate::values::transducers::INTO_MAX)
+        .register_value("into-min", crate::values::transducers::INTO_MIN)
+        .register_value("into-count", crate::values::transducers::INTO_COUNT)
+        .register_value("into-list", crate::values::transducers::INTO_LIST)
+        .register_value("into-vector", crate::values::transducers::INTO_VECTOR)
+        .register_value("into-hashmap", crate::values::transducers::INTO_HASHMAP)
+        .register_value("into-hashset", crate::values::transducers::INTO_HASHSET)
+        .register_value("into-string", crate::values::transducers::INTO_STRING)
+        .register_value("into-last", crate::values::transducers::INTO_LAST)
+        .register_value("into-for-each", crate::values::transducers::FOR_EACH)
+        .register_value("into-nth", crate::values::transducers::NTH)
+        .register_value("into-reducer", crate::values::transducers::REDUCER);
+    module
+}
 
 #[steel_derive::native(name = "compose", arity = "AtLeast(0)")]
 pub fn compose(args: &[SteelVal]) -> Result<SteelVal> {

--- a/crates/steel-core/src/primitives/transducers.rs
+++ b/crates/steel-core/src/primitives/transducers.rs
@@ -20,6 +20,7 @@ use crate::values::transducers::Transducers;
 //     DROPPING => dropping,
 // );
 
+#[steel_derive::native(name = "compose", arity = "AtLeast(0)")]
 pub fn compose(args: &[SteelVal]) -> Result<SteelVal> {
     let mut transformers = Transducer::new();
     for transducer in args {
@@ -33,25 +34,19 @@ pub fn compose(args: &[SteelVal]) -> Result<SteelVal> {
     Ok(SteelVal::IterV(Gc::new(transformers)))
 }
 
-pub fn enumerating(args: &[SteelVal]) -> Result<SteelVal> {
-    if !args.is_empty() {
-        stop!(ArityMismatch => "enumerating takes no arguments");
-    }
-
+#[steel_derive::function(name = "enumerating")]
+pub fn enumerating() -> Result<SteelVal> {
     let mut transducer = Transducer::new();
     transducer.push(Transducers::Enumerating);
     Ok(SteelVal::IterV(Gc::new(transducer)))
 }
 
-pub fn zipping(args: &[SteelVal]) -> Result<SteelVal> {
-    if args.len() != 1 {
-        stop!(ArityMismatch => format!("zipping takes one argument, found: {}", args.len()));
-    }
-
-    match &args[0] {
+#[steel_derive::function(name = "zipping")]
+pub fn zipping(iterable: &SteelVal) -> Result<SteelVal> {
+    match iterable {
         VectorV(_) | StreamV(_) | StringV(_) | ListV(_) | HashSetV(_) | HashMapV(_) => {
             let mut transducer = Transducer::new();
-            transducer.push(Transducers::Zipping(args[0].clone()));
+            transducer.push(Transducers::Zipping(iterable.clone()));
             Ok(SteelVal::IterV(Gc::new(transducer)))
         }
         v => {
@@ -60,15 +55,12 @@ pub fn zipping(args: &[SteelVal]) -> Result<SteelVal> {
     }
 }
 
-pub fn interleaving(args: &[SteelVal]) -> Result<SteelVal> {
-    if args.len() != 1 {
-        stop!(ArityMismatch => "interleaving takes one argument");
-    }
-
-    match &args[0] {
+#[steel_derive::function(name = "interleaving")]
+pub fn interleaving(iterable: &SteelVal) -> Result<SteelVal> {
+    match &iterable {
         VectorV(_) | StreamV(_) | StringV(_) | ListV(_) | HashSetV(_) | HashMapV(_) => {
             let mut transducer = Transducer::new();
-            transducer.push(Transducers::Interleaving(args[0].clone()));
+            transducer.push(Transducers::Interleaving(iterable.clone()));
             Ok(SteelVal::IterV(Gc::new(transducer)))
         }
         v => {
@@ -77,30 +69,24 @@ pub fn interleaving(args: &[SteelVal]) -> Result<SteelVal> {
     }
 }
 
-pub fn map(args: &[SteelVal]) -> Result<SteelVal> {
-    if args.len() != 1 {
-        stop!(ArityMismatch => "mapping takes one argument");
-    }
-
-    match &args[0] {
+#[steel_derive::function(name = "mapping")]
+pub fn map(func: &SteelVal) -> Result<SteelVal> {
+    match &func {
         Closure(_) | FuncV(_) | BoxedFunction(_) | BuiltIn(_) | MutFunc(_) => {
             let mut transducer = Transducer::new();
-            transducer.push(Transducers::Map(args[0].clone()));
+            transducer.push(Transducers::Map(func.clone()));
             Ok(SteelVal::IterV(Gc::new(transducer)))
         }
         v => stop!(TypeMismatch => format!("mapping expects a function, found: {v:?}")),
     }
 }
 
-pub fn extending(args: &[SteelVal]) -> Result<SteelVal> {
-    if args.len() != 1 {
-        stop!(ArityMismatch => "extending takes one argument");
-    }
-
-    match &args[0] {
+#[steel_derive::function(name = "extending")]
+pub fn extending(iterable: &SteelVal) -> Result<SteelVal> {
+    match &iterable {
         VectorV(_) | StreamV(_) | StringV(_) | ListV(_) | HashSetV(_) | HashMapV(_) => {
             let mut transducer = Transducer::new();
-            transducer.push(Transducers::Extend(args[0].clone()));
+            transducer.push(Transducers::Extend(iterable.clone()));
             Ok(SteelVal::IterV(Gc::new(transducer)))
         }
         v => {
@@ -109,15 +95,12 @@ pub fn extending(args: &[SteelVal]) -> Result<SteelVal> {
     }
 }
 
-pub fn flat_map(args: &[SteelVal]) -> Result<SteelVal> {
-    if args.len() != 1 {
-        stop!(ArityMismatch => "mapping takes one argument");
-    }
-
-    match &args[0] {
+#[steel_derive::function(name = "flat-mapping")]
+pub fn flat_map(func: &SteelVal) -> Result<SteelVal> {
+    match &func {
         Closure(_) | FuncV(_) | BoxedFunction(_) | BuiltIn(_) | MutFunc(_) => {
             let mut transducer = Transducer::new();
-            transducer.push(Transducers::FlatMap(args[0].clone()));
+            transducer.push(Transducers::FlatMap(func.clone()));
             Ok(SteelVal::IterV(Gc::new(transducer)))
         }
         v => {
@@ -126,53 +109,41 @@ pub fn flat_map(args: &[SteelVal]) -> Result<SteelVal> {
     }
 }
 
-pub fn flatten(args: &[SteelVal]) -> Result<SteelVal> {
-    if !args.is_empty() {
-        stop!(ArityMismatch => "flattening takes no arguments");
-    }
-
+#[steel_derive::function(name = "flattening")]
+pub fn flatten() -> Result<SteelVal> {
     let mut transducer = Transducer::new();
     transducer.push(Transducers::Flatten);
     Ok(SteelVal::IterV(Gc::new(transducer)))
 }
 
-pub fn filter(args: &[SteelVal]) -> Result<SteelVal> {
-    if args.len() != 1 {
-        stop!(ArityMismatch => "filtering takes one argument");
-    }
-
-    match &args[0] {
+#[steel_derive::function(name = "filtering")]
+pub fn filter(func: &SteelVal) -> Result<SteelVal> {
+    match &func {
         Closure(_) | FuncV(_) | BoxedFunction(_) | BuiltIn(_) | MutFunc(_) => {
             let mut transducer = Transducer::new();
-            transducer.push(Transducers::Filter(args[0].clone()));
+            transducer.push(Transducers::Filter(func.clone()));
             Ok(SteelVal::IterV(Gc::new(transducer)))
         }
         _ => stop!(TypeMismatch => "filtering expects a function"),
     }
 }
 
-pub fn take(args: &[SteelVal]) -> Result<SteelVal> {
-    if args.len() != 1 {
-        stop!(ArityMismatch => "taking takes one argument");
-    }
-
-    if let IntV(_) = &args[0] {
+#[steel_derive::function(name = "taking")]
+pub fn take(amt: &SteelVal) -> Result<SteelVal> {
+    if let IntV(_) = &amt {
         let mut transducer = Transducer::new();
-        transducer.push(Transducers::Take(args[0].clone()));
+        transducer.push(Transducers::Take(amt.clone()));
         Ok(SteelVal::IterV(Gc::new(transducer)))
     } else {
         stop!(TypeMismatch => "taking expects an integer")
     }
 }
 
-pub fn dropping(args: &[SteelVal]) -> Result<SteelVal> {
-    if args.len() != 1 {
-        stop!(ArityMismatch => "dropping takes one argument");
-    }
-
-    if let IntV(_) = &args[0] {
+#[steel_derive::function(name = "dropping")]
+pub fn dropping(amt: &SteelVal) -> Result<SteelVal> {
+    if let IntV(_) = amt {
         let mut transducer = Transducer::new();
-        transducer.push(Transducers::Drop(args[0].clone()));
+        transducer.push(Transducers::Drop(amt.clone()));
         Ok(SteelVal::IterV(Gc::new(transducer)))
     } else {
         stop!(TypeMismatch => "dropping expects an integer")

--- a/crates/steel-core/src/steel_vm/primitives.rs
+++ b/crates/steel-core/src/steel_vm/primitives.rs
@@ -33,6 +33,7 @@ use crate::{
         string_module, symbol_module,
         tcp::tcp_module,
         time::time_module,
+        transducers::transducer_module,
         vectors::{
             immutable_vectors_module, IMMUTABLE_VECTOR_CONSTRUCT_DEFINITION,
             LIST_VEC_NULL_DEFINITION, MAKE_VECTOR_DEFINITION, MUTABLE_VECTOR_CLEAR_DEFINITION,
@@ -1274,40 +1275,6 @@ fn ord_module() -> BuiltInModule {
         .register_native_fn_definition(GREATER_THAN_EQUAL_DEFINITION)
         .register_native_fn_definition(LESS_THAN_DEFINITION)
         .register_native_fn_definition(LESS_THAN_EQUAL_DEFINITION);
-    module
-}
-
-pub fn transducer_module() -> BuiltInModule {
-    let mut module = BuiltInModule::new("steel/transducers");
-
-    use crate::primitives::transducers::*;
-
-    module
-        .register_native_fn_definition(COMPOSE_DEFINITION)
-        .register_native_fn_definition(MAP_DEFINITION)
-        .register_native_fn_definition(FLATTEN_DEFINITION)
-        .register_native_fn_definition(FLAT_MAP_DEFINITION)
-        .register_native_fn_definition(FILTER_DEFINITION)
-        .register_native_fn_definition(TAKE_DEFINITION)
-        .register_native_fn_definition(DROPPING_DEFINITION)
-        .register_native_fn_definition(EXTENDING_DEFINITION)
-        .register_native_fn_definition(ENUMERATING_DEFINITION)
-        .register_native_fn_definition(ZIPPING_DEFINITION)
-        .register_native_fn_definition(INTERLEAVING_DEFINITION)
-        .register_value("into-sum", crate::values::transducers::INTO_SUM)
-        .register_value("into-product", crate::values::transducers::INTO_PRODUCT)
-        .register_value("into-max", crate::values::transducers::INTO_MAX)
-        .register_value("into-min", crate::values::transducers::INTO_MIN)
-        .register_value("into-count", crate::values::transducers::INTO_COUNT)
-        .register_value("into-list", crate::values::transducers::INTO_LIST)
-        .register_value("into-vector", crate::values::transducers::INTO_VECTOR)
-        .register_value("into-hashmap", crate::values::transducers::INTO_HASHMAP)
-        .register_value("into-hashset", crate::values::transducers::INTO_HASHSET)
-        .register_value("into-string", crate::values::transducers::INTO_STRING)
-        .register_value("into-last", crate::values::transducers::INTO_LAST)
-        .register_value("into-for-each", crate::values::transducers::FOR_EACH)
-        .register_value("into-nth", crate::values::transducers::NTH)
-        .register_value("into-reducer", crate::values::transducers::REDUCER);
     module
 }
 

--- a/crates/steel-core/src/steel_vm/primitives.rs
+++ b/crates/steel-core/src/steel_vm/primitives.rs
@@ -53,7 +53,7 @@ use crate::{
         CustomType, FromSteelVal, SteelString, ITERATOR_FINISHED, NUMBER_EQUALITY_DEFINITION,
     },
     steel_vm::{
-        builtin::{get_function_metadata, get_function_name, Arity, BuiltInFunctionType},
+        builtin::{get_function_metadata, get_function_name, BuiltInFunctionType},
         vm::threads::threading_module,
     },
     values::{
@@ -1283,17 +1283,17 @@ pub fn transducer_module() -> BuiltInModule {
     use crate::primitives::transducers::*;
 
     module
-        .register_native_fn("compose", compose, Arity::AtLeast(0))
-        .register_native_fn("mapping", map, Arity::Exact(1))
-        .register_native_fn("flattening", flatten, Arity::Exact(0))
-        .register_native_fn("flat-mapping", flat_map, Arity::Exact(1))
-        .register_native_fn("filtering", filter, Arity::Exact(1))
-        .register_native_fn("taking", take, Arity::Exact(1))
-        .register_native_fn("dropping", dropping, Arity::Exact(1))
-        .register_native_fn("extending", extending, Arity::Exact(1))
-        .register_native_fn("enumerating", enumerating, Arity::Exact(0))
-        .register_native_fn("zipping", zipping, Arity::Exact(1))
-        .register_native_fn("interleaving", interleaving, Arity::Exact(1))
+        .register_native_fn_definition(COMPOSE_DEFINITION)
+        .register_native_fn_definition(MAP_DEFINITION)
+        .register_native_fn_definition(FLATTEN_DEFINITION)
+        .register_native_fn_definition(FLAT_MAP_DEFINITION)
+        .register_native_fn_definition(FILTER_DEFINITION)
+        .register_native_fn_definition(TAKE_DEFINITION)
+        .register_native_fn_definition(DROPPING_DEFINITION)
+        .register_native_fn_definition(EXTENDING_DEFINITION)
+        .register_native_fn_definition(ENUMERATING_DEFINITION)
+        .register_native_fn_definition(ZIPPING_DEFINITION)
+        .register_native_fn_definition(INTERLEAVING_DEFINITION)
         .register_value("into-sum", crate::values::transducers::INTO_SUM)
         .register_value("into-product", crate::values::transducers::INTO_PRODUCT)
         .register_value("into-max", crate::values::transducers::INTO_MAX)

--- a/crates/steel-core/src/steel_vm/vm.rs
+++ b/crates/steel-core/src/steel_vm/vm.rs
@@ -3053,7 +3053,7 @@ impl<'a> VmCore<'a> {
         std::mem::replace(&mut self.thread.stack[offset], SteelVal::Void)
     }
 
-    fn current_span_for_index(&self, ip: usize) -> Span {
+    pub(crate) fn current_span_for_index(&self, ip: usize) -> Span {
         self.thread
             .stack_frames
             .last()
@@ -3075,6 +3075,10 @@ impl<'a> VmCore<'a> {
     // We will probably end up grabbing a garbage span
     fn current_span(&self) -> Span {
         self.current_span_for_index(self.ip)
+    }
+
+    pub(crate) fn previous_span(&self) -> Span {
+        self.current_span_for_index(self.ip - 1)
     }
 
     // TODO: Tail calls see to obfuscate the proper span information.

--- a/docs/src/builtins/steel_base.md
+++ b/docs/src/builtins/steel_base.md
@@ -497,6 +497,18 @@ Checks if the given value is a complex number
 > (complex? 42) ;; => #t
 > (complex? "hello") ;; => #f
 ```
+### **compose**
+Compose multiple iterators into one iterator
+
+(compose . iters) -> iterator?
+
+#### Examples
+```scheme
+(compose
+(mapping (λ (x) (+ x 1)))
+(filtering odd?)
+(taking 15))
+```
 ### **cons**
 Returns a newly allocated list whose first element is `a` and second element is `d`.
 
@@ -607,6 +619,15 @@ Retrieves the denominator of the given rational number.
 Returns `#t` if the value is an disconnected-channel object.
 
 (eof-object? any/c) -> bool?
+### **dropping**
+Creates a taking iterator combinator
+
+(dropping integer?) -> iterator?
+
+#### Examples
+```scheme
+(transduce (list 1 2 3 4 5) (dropping 3) (into-list)) ;; => '(4 5)
+```
 ### **duration->string**
 Returns a string representation of a duration
 
@@ -643,6 +664,15 @@ pattern: string?
 ```scheme
 > (ends-with? "foobar" "foo") ;; => #false
 > (ends-with? "foobar" "bar") ;; => #true
+```
+### **enumerating**
+Create an enumerating iterator
+
+(enumerating) -> iterator?
+
+#### Examples
+```scheme
+(transduce (list 1 3 5) (enumerating) (into-list)) ;; => '((0 1) (1 3) (2 5))
 ```
 ### **eof-object**
 Returns an EOF object.
@@ -760,6 +790,15 @@ Raises the left operand to the power of the right operand.
 > (expt 2.0 0.5) ;; => 1.4142135623730951
 > (expt 9 0.5) ;; => 3
 ```
+### **extending**
+Create an extending iterator
+
+(extending iterable) -> iterator?
+
+#### Examples
+```scheme
+(transduce (list 1 2 3) (extending (list 4 5 6 7)) (into-list)) ;; => '(1 2 3 4 5 6 7)
+```
 ### **f+**
 Sums all given floats
 
@@ -786,6 +825,15 @@ Gets the filename for a given path
 ```scheme
 > (file-name "logs") ;; => "logs"
 > (file-name "logs/today.json") ;; => "today.json"
+```
+### **filtering**
+Creates a filtering iterator
+
+(filtering proc?) -> iterator?
+
+#### Examples
+```scheme
+(transduce (list 1 2 3 4) (filtering even?) (into-list)) ;; => '(2 4)
 ```
 ### **finite?**
 Returns `#t` if the given number is finite.
@@ -814,6 +862,24 @@ Returns the first element of the list l.
 ```scheme
 > (first '(1 2)) ;; => 1
 > (first (cons 2 3)) ;; => 2
+```
+### **flat-mapping**
+Creates a flat-mapping iterator
+
+(flat-mapping proc?) -> iterator
+
+#### Examples
+```scheme
+(transduce (list 1 2 3) (flat-mapping (λ (x) (range 0 x))) (into-list)) ;; => '(0 0 1 0 1 2)
+```
+### **flattening**
+Creates a flattening iterator that etc
+
+(flattening) -> iterator?
+
+#### Examples
+```scheme
+(transduce (list '(1 2) '(3 4) '(5 6)) (flattening) (into-list)) ;; => '(1 2 3 4 5 6)
 ```
 ### **float?**
 Checks if the given value is a floating-point number
@@ -1256,6 +1322,15 @@ Checks if the given value is an integer, an alias for `int?`
 > (integer? 3.14) ;; => #f
 > (integer? "hello") ;; => #f
 ```
+### **interleaving**
+Create an interleaving iterator
+
+(interleaving any/c) -> iterator?
+
+#### Examples
+```scheme
+(transduce (list 1 2 3) (interleaving (list 4 5 6)) (into-list)) ;; => '(1 4 2 5 3 6)
+```
 ### **is-dir?**
 Checks if a path is a directory
 
@@ -1443,6 +1518,15 @@ Creates a mutable vector of a given size, optionally initialized with a specifie
 ```scheme
 > (make-vector 3) ;; => '#(0 0 0)
 > (make-vector 3 42) ;; => '#(42 42 42)
+```
+### **mapping**
+Create a mapping iterator
+
+(mapping proc?) -> iterator?
+
+#### Examples
+```scheme
+(transduce (list 1 2 3) (mapping (λ (x) (+ x 1))) (into-list)) ;; => '(2 3 4)
 ```
 ### **modulo**
 Returns the euclidean remainder of the division of the first number by the second
@@ -2475,6 +2559,15 @@ Returns the first n elements of the list l as a new list.
 > (take '(1 2 3 4) 2) ;; => '(0 1)
 > (take (range 0 10) 4) ;; => '(0 1 2 3)
 ```
+### **taking**
+Creates a taking iterator combinator
+
+(taking number?) -> iterator?
+
+#### Examples
+```scheme
+(transduce (list 1 2 3 4 5) (taking 3) (into-list)) ;; => '(1 2 3)
+```
 ### **tan**
 Returns the tangent value of the input angle, measured in radians.
 
@@ -2768,6 +2861,15 @@ Checks if the given real number is zero.
 > (zero? 0.0) ;; => #t
 > (zero? 0.1) ;; => #f
 ```
+### **zipping**
+Create a zipping iterator
+
+(zipping any/c) -> iterator?
+
+#### Examples
+```scheme
+(transduce (list 1 2 3) (zipping (list 4 5 6 7)) (into-list)) ;; => '((1 4) (2 5) (3 6))
+```
 ### **%#interner-memory-usage**
 ### **%iterator?**
 ### **%keyword-hash**
@@ -2820,18 +2922,15 @@ Checks if the given real number is zero.
 ### **child-stdin**
 ### **child-stdout**
 ### **command**
-### **compose**
 ### **concat-symbols**
 ### **continuation?**
 ### **current-function-span**
 ### **current-os!**
 ### **current-thread-id**
-### **dropping**
 ### **duration->seconds**
 ### **duration-since**
 ### **emit-expanded**
 ### **empty-stream**
-### **enumerating**
 ### **env-var**
 ### **eq?**
 ### **equal?**
@@ -2842,11 +2941,7 @@ Checks if the given real number is zero.
 ### **eval!**
 ### **eval-string**
 ### **expand!**
-### **extending**
 ### **feature-dylib-build?**
-### **filtering**
-### **flat-mapping**
-### **flattening**
 ### **flush-output-port**
 ### **function-name**
 ### **function?**
@@ -2859,7 +2954,6 @@ Checks if the given real number is zero.
 ### **inspect**
 ### **instant/elapsed**
 ### **instant/now**
-### **interleaving**
 ### **into-count**
 ### **into-for-each**
 ### **into-hashmap**
@@ -2888,7 +2982,6 @@ Checks if the given real number is zero.
 ### **local-executor/block-on**
 ### **make-channels**
 ### **make-struct-type**
-### **mapping**
 ### **maybe-get-env-var**
 ### **memory-address**
 ### **multi-arity?**
@@ -2950,7 +3043,6 @@ Checks if the given real number is zero.
 ### **system-time<?**
 ### **system-time>=**
 ### **system-time>?**
-### **taking**
 ### **thread/available-parallelism**
 ### **thread::current/id**
 ### **transduce**
@@ -2967,4 +3059,3 @@ Checks if the given real number is zero.
 ### **which**
 ### **would-block**
 ### **write-line!**
-### **zipping**

--- a/docs/src/builtins/steel_lists.md
+++ b/docs/src/builtins/steel_lists.md
@@ -281,5 +281,4 @@ error[E11]: Generic
 ### **plist-try-get-positional-arg**
 ### **plist-validate-args**
 ### **push-back**
-### **transduce**
 ### **try-list-ref**

--- a/docs/src/builtins/steel_transducers.md
+++ b/docs/src/builtins/steel_transducers.md
@@ -115,3 +115,4 @@ Create a zipping iterator
 ### **into-string**
 ### **into-sum**
 ### **into-vector**
+### **transduce**

--- a/docs/src/builtins/steel_transducers.md
+++ b/docs/src/builtins/steel_transducers.md
@@ -1,12 +1,106 @@
 # steel/transducers
 ### **compose**
+Compose multiple iterators into one iterator
+
+(compose . iters) -> iterator?
+
+#### Examples
+```scheme
+(compose
+(mapping (λ (x) (+ x 1)))
+(filtering odd?)
+(taking 15))
+```
 ### **dropping**
+Creates a taking iterator combinator
+
+(dropping integer?) -> iterator?
+
+#### Examples
+```scheme
+(transduce (list 1 2 3 4 5) (dropping 3) (into-list)) ;; => '(4 5)
+```
 ### **enumerating**
+Create an enumerating iterator
+
+(enumerating) -> iterator?
+
+#### Examples
+```scheme
+(transduce (list 1 3 5) (enumerating) (into-list)) ;; => '((0 1) (1 3) (2 5))
+```
 ### **extending**
+Create an extending iterator
+
+(extending iterable) -> iterator?
+
+#### Examples
+```scheme
+(transduce (list 1 2 3) (extending (list 4 5 6 7)) (into-list)) ;; => '(1 2 3 4 5 6 7)
+```
 ### **filtering**
+Creates a filtering iterator
+
+(filtering proc?) -> iterator?
+
+#### Examples
+```scheme
+(transduce (list 1 2 3 4) (filtering even?) (into-list)) ;; => '(2 4)
+```
 ### **flat-mapping**
+Creates a flat-mapping iterator
+
+(flat-mapping proc?) -> iterator
+
+#### Examples
+```scheme
+(transduce (list 1 2 3) (flat-mapping (λ (x) (range 0 x))) (into-list)) ;; => '(0 0 1 0 1 2)
+```
 ### **flattening**
+Creates a flattening iterator that etc
+
+(flattening) -> iterator?
+
+#### Examples
+```scheme
+(transduce (list '(1 2) '(3 4) '(5 6)) (flattening) (into-list)) ;; => '(1 2 3 4 5 6)
+```
 ### **interleaving**
+Create an interleaving iterator
+
+(interleaving any/c) -> iterator?
+
+#### Examples
+```scheme
+(transduce (list 1 2 3) (interleaving (list 4 5 6)) (into-list)) ;; => '(1 4 2 5 3 6)
+```
+### **mapping**
+Create a mapping iterator
+
+(mapping proc?) -> iterator?
+
+#### Examples
+```scheme
+(transduce (list 1 2 3) (mapping (λ (x) (+ x 1))) (into-list)) ;; => '(2 3 4)
+```
+### **taking**
+Creates a taking iterator combinator
+
+(taking number?) -> iterator?
+
+#### Examples
+```scheme
+(transduce (list 1 2 3 4 5) (taking 3) (into-list)) ;; => '(1 2 3)
+```
+### **zipping**
+Create a zipping iterator
+
+(zipping any/c) -> iterator?
+
+#### Examples
+```scheme
+(transduce (list 1 2 3) (zipping (list 4 5 6 7)) (into-list)) ;; => '((1 4) (2 5) (3 6))
+```
 ### **into-count**
 ### **into-for-each**
 ### **into-hashmap**
@@ -21,6 +115,3 @@
 ### **into-string**
 ### **into-sum**
 ### **into-vector**
-### **mapping**
-### **taking**
-### **zipping**

--- a/docs/src/reference/transducers.md
+++ b/docs/src/reference/transducers.md
@@ -14,27 +14,20 @@ Inspired by clojure's transducers, `Steel` has a similar object that is somewher
     (taking 15)) ;; => <#iterator>
 ```
 
-Each of these expressions emit an `<#iterator>` object, which means they're compatible with `execute` and `transduce`. Execute takes a transducer (i.e. `<#iterator>`) and a collection that can be iterated (`list`, `vector`, or `stream`) and applies the transducer.
+Each of these expressions emit an `<#iterator>` object, which means they're compatible with `transduce`. Transduce takes a collection that can be iterated (`list`, `vector`, or `stream`), a transducer (i.e. `<#iterator>`) and a reducer, which dictates how the element are combined into a result value.
 
 ```scheme
 ;; Accepts lists
-(execute (mapping (lambda (x) (+ x 1))) (list 1 2 3 4 5)) ;; => '(2 3 4 5 6)
+(transduce (mapping (lambda (x) (+ x 1))) (list 1 2 3 4 5) (into-list)) ;; => '(2 3 4 5 6)
 
 ;; Accepts vectors
-(execute (mapping (lambda (x) (+ x 1))) (vector 1 2 3 4 5)) ;; '#(2 3 4 5 6)
+(transduce (vector 1 2 3 4 5) (mapping (lambda (x) (+ x 1))) (into-vector)) ;; '#(2 3 4 5 6)
 
 ;; Even accepts streams!
 (define (integers n)
     (stream-cons n (lambda () (integers (+ 1 n)))))
 
-(execute (taking 5) (integers 0)) ;; => '(0 1 2 3 4)
-```
-
-Transduce is just `reduce` with more bells and whistles and works similarly:
-
-```scheme
-;; (-> transducer reducing-function initial-value iterable)
-(transduce (mapping (lambda (x) (+ x 1))) + 0 (list 0 1 2 3)) ;; => 10
+(transduce (integers 0) (taking 5) (into-list)) ;; => '(0 1 2 3 4)
 ```
 
 Compose just combines the iterator functions and lets us avoid intermediate allocation. The composition works left to right - it chains each value through the functions and then accumulates into the output type. See the following:
@@ -46,21 +39,5 @@ Compose just combines the iterator functions and lets us avoid intermediate allo
         (filtering odd?)
         (taking 5)))
 
-(execute xf (range 0 100)) ;; => '(1 3 5 7 9)
-```
-
-By default, execute outputs to the same type that was passed in. In other words, if you `execute` a `list`, it will return a `list`. However, if you so choose, you can pass in a symbol specifying the output type of your choosing like so:
-
-```scheme
-(define xf 
-    (compose 
-        (mapping add1)
-        (filtering odd?)
-        (taking 5)))
-
-;; Takes a list and returns a vector
-(execute xf (range 0 100) 'vector) ;; => '#(1 3 5 7 9)
-
-;; Takes a vector and returns a list
-(execute xf (vector 0 1 2 3 4 5 6 7 8 9 10) 'list) ;; => '(1 3 5 7 9)
+(transduce (range 0 100) xf (into-list)) ;; => '(1 3 5 7 9)
 ```


### PR DESCRIPTION
the biggest change here is that i implemented the `execute` iterator consumer. the possible return types specified by the symbol are `'list`, `'vector`, `'string`, `'hashset` and `'hashmap`. there is a few things that i was not quite sure with how to do so i just did the best i could. when executing on a `MutableVector` it currently collects into a `VectorV` and when executing on a `StreamV` it currently returns a `ListV`. i didn't want to implement another reducer for this, but i think that that will be doable another time.

the comment about the `Range(n)` arity from #347 also applies here.

as i am not very good at writing documentation, the documentation is a little basic, but i think the examples mostly speak for themselves.

i also implemented VmCore::previous_span. for execute i needed a steel_derive::context() and i wanted to give useful errors, and this was the cleanest solution that i managed to come up with.