### PR TITLE
add `trim` method to `match line`

### DIFF
--- a/crates/cargo-steel-lib/src/lib.rs
+++ b/crates/cargo-steel-lib/src/lib.rs
@@ -43,6 +43,10 @@ pub fn run(args: Vec<String>, env_vars: Vec<(String, String)>) -> Result<(), Box
 
     steel_home.push("native");
 
+    if !steel_home.exists() {
+        std::fs::create_dir(&steel_home)?;
+    }
+
     // --manifest-path
     let mut metadata_command = MetadataCommand::new();
 

--- a/crates/steel-core/src/primitives/lists.rs
+++ b/crates/steel-core/src/primitives/lists.rs
@@ -295,31 +295,36 @@ macro_rules! debug_unreachable {
 //     }
 // }
 
-/// Returns a newly allocated list of the elements in the range (n, m]
+/// Returns a newly allocated list of the elements in the range [n, m) or [0, m) when n is not given.
 ///
+/// (range m)   -> (listof int?)
 /// (range n m) -> (listof int?)
 ///
 /// * n : int?
 /// * m : int?
 ///
 /// ```scheme
-/// > (range 0 10) ;; => '(0 1 2 3 4 5 6 7 8 9)
+/// > (range 4) ;; => '(0 1 2 3)
+/// > (range 4 10) ;; => '(4 5 6 7 8 9)
 /// ```
-#[steel_derive::function(name = "range")]
-fn range(lower: isize, upper: isize) -> Result<SteelVal> {
-    if lower < 0 {
-        stop!(Generic => "range expects a positive integer");
-    }
+#[steel_derive::native(name = "range", arity = "AtMost(2)")]
+fn range(args: &[SteelVal]) -> Result<SteelVal> {
+    let (lower, upper) = match args {
+        [] => stop!(ArityMismatch => "range expected one or two arguments, got 0"),
+        [SteelVal::IntV(upper)] => (0, *upper),
+        [SteelVal::IntV(lower), SteelVal::IntV(upper)] => (*lower, *upper),
+        [invalid] | [SteelVal::IntV(_), invalid] | [invalid, _] => {
+            stop!(TypeMismatch => "range expects integer, got {}", invalid)
+        }
+        _ => stop!(ArityMismatch => "range expected one or two arguments, got {}", args.len()),
+    };
 
-    if upper < 0 {
+    if lower < 0 || upper < 0 {
         stop!(Generic => "range expects a positive integer");
     }
 
     Ok(SteelVal::ListV(
-        (lower as usize..upper as usize)
-            .into_iter()
-            .map(|x| SteelVal::IntV(x as isize))
-            .collect(),
+        (lower..upper).into_iter().map(SteelVal::IntV).collect(),
     ))
 }
 
@@ -942,9 +947,17 @@ mod list_operation_tests {
 
     #[test]
     fn range_tests_arity_too_few() {
-        let args = [SteelVal::IntV(1)];
-        let res = steel_range(&args);
+        let args = [];
+        let res = range(&args);
         let expected = ErrorKind::ArityMismatch;
+        assert_eq!(res.unwrap_err().kind(), expected);
+    }
+
+    #[test]
+    fn range_tests_type_mismatch() {
+        let args = [SteelVal::StringV("test".into()), SteelVal::IntV(1)];
+        let res = range(&args);
+        let expected = ErrorKind::TypeMismatch;
         assert_eq!(res.unwrap_err().kind(), expected);
     }
 
@@ -955,17 +968,25 @@ mod list_operation_tests {
             SteelVal::NumV(2.0),
             SteelVal::NumV(3.0),
         ];
-        let res = steel_range(&args);
+        let res = range(&args);
         let expected = ErrorKind::ArityMismatch;
         assert_eq!(res.unwrap_err().kind(), expected);
     }
 
     #[test]
+    fn range_tests_single_element() {
+        let args = [SteelVal::IntV(2)];
+        let res = range(&args);
+        let expected = SteelVal::ListV(vec![SteelVal::IntV(0), SteelVal::IntV(1)].into());
+        assert_eq!(res.unwrap(), expected);
+    }
+
+    #[test]
     fn range_test_normal_input() {
-        let args = [SteelVal::IntV(0), SteelVal::IntV(3)];
-        let res = steel_range(&args);
+        let args = [SteelVal::IntV(2), SteelVal::IntV(5)];
+        let res = range(&args);
         let expected =
-            SteelVal::ListV(vec![SteelVal::IntV(0), SteelVal::IntV(1), SteelVal::IntV(2)].into());
+            SteelVal::ListV(vec![SteelVal::IntV(2), SteelVal::IntV(3), SteelVal::IntV(4)].into());
         assert_eq!(res.unwrap(), expected);
     }
 }

--- a/crates/steel-core/src/steel_vm/ffi.rs
+++ b/crates/steel-core/src/steel_vm/ffi.rs
@@ -673,6 +673,18 @@ impl<T: IntoFFIVal> IntoFFIVal for Vec<T> {
     }
 }
 
+impl<T: IntoFFIVal, V: IntoFFIVal> IntoFFIVal for std::collections::HashMap<T, V> {
+    fn into_ffi_val(self) -> RResult<FFIValue, RBoxError> {
+        let mut output = RHashMap::with_capacity(self.len());
+
+        for (key, value) in self {
+            output.insert(ffi_try!(key.into_ffi_val()), ffi_try!(value.into_ffi_val()));
+        }
+
+        RResult::ROk(FFIValue::HashMap(output))
+    }
+}
+
 impl IntoFFIVal for RResult<FFIValue, RBoxError> {
     fn into_ffi_val(self) -> RResult<FFIValue, RBoxError> {
         self

--- a/crates/steel-parser/src/tokens.rs
+++ b/crates/steel-parser/src/tokens.rs
@@ -2,7 +2,8 @@ use crate::lexer;
 use crate::parser::SourceId;
 use crate::span::Span;
 use core::ops;
-use num::{BigInt, Rational32, Signed};
+use num::bigint::ParseBigIntError;
+use num::{BigInt, Num, Rational32, Signed};
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::fmt::{self, Display};
@@ -219,6 +220,16 @@ pub enum IntLiteral {
 }
 
 impl IntLiteral {
+    pub fn from_str_radix(src: &str, radix: u32) -> Result<IntLiteral, ParseBigIntError> {
+        isize::from_str_radix(src, radix)
+            .map(IntLiteral::Small)
+            .or_else(|_| {
+                BigInt::from_str_radix(src, radix)
+                    .map(Box::new)
+                    .map(IntLiteral::Big)
+            })
+    }
+
     fn is_negative(&self) -> bool {
         match self {
             IntLiteral::Small(i) => i.is_negative(),

--- a/crates/steel-repl/src/repl.rs
+++ b/crates/steel-repl/src/repl.rs
@@ -290,7 +290,7 @@ pub fn repl_base(mut vm: Engine) -> std::io::Result<()> {
         match readline {
             Ok(line) => {
                 rl.add_history_entry(line.as_str()).ok();
-                match line.as_str() {
+                match line.as_str().trim() {
                     ":q" | ":quit" => return Ok(()),
                     ":time" => {
                         print_time = !print_time;

--- a/docs/src/builtins/steel_base.md
+++ b/docs/src/builtins/steel_base.md
@@ -1775,15 +1775,17 @@ Returns quotient of dividing numerator by denomintator.
 > (quotient -10 2) ;; => -5
 ```
 ### **range**
-Returns a newly allocated list of the elements in the range (n, m]
+Returns a newly allocated list of the elements in the range [n, m) or [0, m) when n is not given.
 
+(range m)   -> (listof int?)
 (range n m) -> (listof int?)
 
 * n : int?
 * m : int?
 
 ```scheme
-> (range 0 10) ;; => '(0 1 2 3 4 5 6 7 8 9)
+> (range 4) ;; => '(0 1 2 3)
+> (range 4 10) ;; => '(4 5 6 7 8 9)
 ```
 ### **range-vec**
 Constructs a vector containing a range of integers from `start` to `end` (exclusive).

--- a/docs/src/builtins/steel_lists.md
+++ b/docs/src/builtins/steel_lists.md
@@ -177,15 +177,17 @@ Checks if the given value can be treated as a pair.
 > (pair? '()) ;; => #false
 ```
 ### **range**
-Returns a newly allocated list of the elements in the range (n, m]
+Returns a newly allocated list of the elements in the range [n, m) or [0, m) when n is not given.
 
+(range m)   -> (listof int?)
 (range n m) -> (listof int?)
 
 * n : int?
 * m : int?
 
 ```scheme
-> (range 0 10) ;; => '(0 1 2 3 4 5 6 7 8 9)
+> (range 4) ;; => '(0 1 2 3)
+> (range 4 10) ;; => '(4 5 6 7 8 9)
 ```
 ### **rest**
 Returns the rest of the list. Will raise an error if the list is empty.

--- a/docs/src/start/dylib.md
+++ b/docs/src/start/dylib.md
@@ -55,7 +55,12 @@ crate-type = ["cdylib"]
 [dependencies]
 # I'm running this example based on the `steel-sys-info` library found in the steel repo. If you're
 # running this on your own, use whichever steel version you'd like to target and pin to that.
-steel-core = { workspace = true, features = ["dylibs"] }
+steel-core = { workspace = true, features = ["dylibs", "sync"] }
+
+# Note: If you're not using the default features, and you aren't opted into the `sync` feature,
+# you'll need to have the features line up here.
+# steel-core = { workspace = true, features = ["dylibs"] }
+
 abi_stable = "0.11.1"
 sys-info = "0.9.1"
 ```


### PR DESCRIPTION
i use stenotypy and text expansion a lot, which adds a space at the end of words.  i hope this pr can be accepted so that i don't have to delete the trailing space every time i enter a command, i.e. `:time ` and `:help `