### PR TITLE
Fix Nix shell used by .envrc and nix develop

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1714906307,
-        "narHash": "sha256-UlRZtrCnhPFSJlDQE7M0eyhgvuuHBTe1eJ9N9AQlJQ0=",
+        "lastModified": 1744098102,
+        "narHash": "sha256-tzCdyIJj9AjysC3OuKA+tMD/kDEDAF9mICPDU7ix0JA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "25865a40d14b3f9cf19f19b924e2ab4069b09588",
+        "rev": "c8cd81426f45942bb2906d5ed2fe21d2f19d95b7",
         "type": "github"
       },
       "original": {

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,15 +1,15 @@
-{
-  lib,
-  stdenv,
-  mkShell,
-  steel,
-  cargo,
-  rustc,
-  libiconv,
-  CoreServices,
-  SystemConfiguration,
-  rust-analyzer,
-  rustfmt,
+{ lib
+, stdenv
+, mkShell
+, steel
+, cargo
+, rustc
+, libiconv
+, CoreServices
+, SystemConfiguration
+, rust-analyzer
+, rustfmt
+,
 }:
 mkShell {
   shellHook = ''
@@ -27,5 +27,5 @@ mkShell {
       CoreServices
       SystemConfiguration
     ];
-    inputsFrom = steel;
+  inputsFrom = [ steel ];
 }


### PR DESCRIPTION
Also bumped the Nix flake.lock, was a year out of date.

Fixes #353