### PR TITLE
add trim method to match line in repl

### DIFF
--- a/crates/steel-repl/src/repl.rs
+++ b/crates/steel-repl/src/repl.rs
@@ -290,7 +290,7 @@ pub fn repl_base(mut vm: Engine) -> std::io::Result<()> {
         match readline {
             Ok(line) => {
                 rl.add_history_entry(line.as_str()).ok();
-                match line.as_str() {
+                match line.as_str().trim() {
                     ":q" | ":quit" => return Ok(()),
                     ":time" => {
                         print_time = !print_time;


### PR DESCRIPTION
sorry about the duplicate PR.  i made a mess of the last one 

i use stenotypy and text expansion a lot, which adds a space at the end of words.  i hope this pr can be accepted so that i don't have to delete the trailing space every time i enter a command, i.e. `:time ` and `:help `