### PR TITLE
properly implement the `string->number` procedure

### DIFF
--- a/crates/steel-core/src/parser/parser.rs
+++ b/crates/steel-core/src/parser/parser.rs
@@ -185,14 +185,7 @@ impl TryFrom<TokenType<InternedString>> for SteelVal {
             CharacterLiteral(x) => Ok(CharV(x)),
             BooleanLiteral(x) => Ok(BoolV(x)),
             Identifier(x) => Ok(SymbolV(x.into())),
-            Number(x) => match *x {
-                NumberLiteral::Real(r) => real_literal_to_steelval(r),
-                NumberLiteral::Complex(re, im) => SteelComplex {
-                    re: real_literal_to_steelval(re)?,
-                    im: real_literal_to_steelval(im)?,
-                }
-                .into_steelval(),
-            },
+            Number(x) => x.into_steelval(),
             StringLiteral(x) => Ok(StringV(x.into())),
             Keyword(x) => Ok(SymbolV(x.into())),
             QuoteTick => Err(SteelErr::new(ErrorKind::UnexpectedToken, "'".to_string())),
@@ -247,14 +240,7 @@ impl TryFrom<SyntaxObject> for SteelVal {
             CharacterLiteral(x) => Ok(CharV(x)),
             BooleanLiteral(x) => Ok(BoolV(x)),
             Identifier(x) => Ok(SymbolV(x.into())),
-            Number(x) => match *x {
-                NumberLiteral::Real(r) => real_literal_to_steelval(r),
-                NumberLiteral::Complex(re, im) => SteelComplex {
-                    re: real_literal_to_steelval(re)?,
-                    im: real_literal_to_steelval(im)?,
-                }
-                .into_steelval(),
-            },
+            Number(x) => x.into_steelval(),
             StringLiteral(x) => Ok(StringV(x.into())),
             Keyword(x) => Ok(SymbolV(x.into())),
             QuoteTick => {

--- a/crates/steel-core/src/parser/parser.rs
+++ b/crates/steel-core/src/parser/parser.rs
@@ -156,6 +156,19 @@ fn real_literal_to_steelval(r: RealLiteral) -> Result<SteelVal, SteelErr> {
     }
 }
 
+impl IntoSteelVal for NumberLiteral {
+    fn into_steelval(self) -> Result<SteelVal, SteelErr> {
+        match self {
+            NumberLiteral::Real(r) => real_literal_to_steelval(r),
+            NumberLiteral::Complex(re, im) => SteelComplex {
+                re: real_literal_to_steelval(re)?,
+                im: real_literal_to_steelval(im)?,
+            }
+            .into_steelval(),
+        }
+    }
+}
+
 impl TryFrom<TokenType<InternedString>> for SteelVal {
     type Error = SteelErr;
 

--- a/crates/steel-core/src/primitives/strings.rs
+++ b/crates/steel-core/src/primitives/strings.rs
@@ -144,11 +144,6 @@ pub fn number_to_string(value: &SteelVal, mut rest: RestArgsIter<'_, isize>) -> 
     number_to_string_impl(value, radix)
 }
 
-fn string_to_number_impl(value: &str, radix: Option<u32>) -> Option<SteelVal> {
-    let number = steel_parser::lexer::parse_number(value, radix)?;
-    number.into_steelval().ok()
-}
-
 /// Converts the given string to a number, with an optional radix.
 /// On failure, it returns `#f`
 ///
@@ -175,10 +170,8 @@ pub fn string_to_number(
         None
     };
 
-    match string_to_number_impl(value.as_str(), radix) {
-        Some(v) => Ok(v),
-        None => Ok(SteelVal::BoolV(false)),
-    }
+    let number = steel_parser::lexer::parse_number(value, radix);
+    number.into_steelval()
 }
 
 /// Constructs a string from the given characters

--- a/crates/steel-core/src/primitives/strings.rs
+++ b/crates/steel-core/src/primitives/strings.rs
@@ -1,11 +1,10 @@
 use crate::gc::Gc;
 use crate::values::lists::{List, SteelList};
 
-use crate::rvals::{RestArgsIter, Result, SteelByteVector, SteelString, SteelVal};
+use crate::rvals::{IntoSteelVal, RestArgsIter, Result, SteelByteVector, SteelString, SteelVal};
 use crate::steel_vm::builtin::BuiltInModule;
 use crate::{stop, Vector};
 
-use num::{BigInt, Num};
 use steel_derive::{function, native};
 
 /// Strings in Steel are immutable, fixed length arrays of characters. They are heap allocated, and
@@ -145,39 +144,9 @@ pub fn number_to_string(value: &SteelVal, mut rest: RestArgsIter<'_, isize>) -> 
     number_to_string_impl(value, radix)
 }
 
-fn string_to_number_impl(value: &str, radix: Option<u32>) -> Result<SteelVal> {
-    let expr = crate::parser::parser::Parser::parse(value)?;
-
-    if expr.len() != 1 {
-        return Ok(SteelVal::BoolV(false));
-    }
-
-    let explicit_radix = matches!(
-        value.get(0..2),
-        Some("#x") | Some("#d") | Some("#o") | Some("#b")
-    );
-
-    let implicit_radix = radix.filter(|_| !explicit_radix);
-
-    let number = expr.into_iter().next().unwrap();
-
-    let svalue = SteelVal::try_from(number)?;
-
-    match (svalue, implicit_radix) {
-        (SteelVal::IntV(_), Some(radix)) => match isize::from_str_radix(value, radix) {
-            Ok(parsed) => Ok(SteelVal::IntV(parsed)),
-            Err(_) => Ok(SteelVal::BoolV(false)),
-        },
-        (val @ SteelVal::IntV(_), None) => Ok(val),
-        (SteelVal::BigNum(_), Some(radix)) => match BigInt::from_str_radix(value, radix) {
-            Ok(parsed) => Ok(SteelVal::BigNum(Gc::new(parsed))),
-            Err(_) => Ok(SteelVal::BoolV(false)),
-        },
-
-        (val @ SteelVal::BigNum(_), None) => Ok(val),
-        (svalue @ SteelVal::NumV(_), _) => Ok(svalue),
-        _ => Ok(SteelVal::BoolV(false)),
-    }
+fn string_to_number_impl(value: &str, radix: Option<u32>) -> Option<SteelVal> {
+    let number = steel_parser::lexer::parse_number(value, radix)?;
+    number.into_steelval().ok()
 }
 
 /// Converts the given string to a number, with an optional radix.
@@ -207,8 +176,8 @@ pub fn string_to_number(
     };
 
     match string_to_number_impl(value.as_str(), radix) {
-        Ok(v) => Ok(v),
-        Err(_) => Ok(SteelVal::BoolV(false)),
+        Some(v) => Ok(v),
+        None => Ok(SteelVal::BoolV(false)),
     }
 }
 

--- a/crates/steel-core/src/tests/success/numbers.scm
+++ b/crates/steel-core/src/tests/success/numbers.scm
@@ -235,3 +235,7 @@
 (assert-equal! '(2 1) (exact-integer-sqrt 5))
 (assert-equal! '(10000000000000000000000 4)
                (exact-integer-sqrt 100000000000000000000000000000000000000000004))
+
+(assert-equal! 255 (string->number "ff" 16))
+(assert-equal! 1+2i (string->number "1+10i" 2))
+(assert-equal! 1/8 (string->number "1/10" 8))

--- a/crates/steel-parser/src/lexer.rs
+++ b/crates/steel-parser/src/lexer.rs
@@ -338,14 +338,14 @@ impl<'a> Lexer<'a> {
                     self.eat();
                 }
                 '(' | ')' | '[' | ']' => {
-                    return if let Some(t) = parse_number(self.slice()) {
+                    return if let Some(t) = parse_number(self.slice(), None) {
                         Ok(t.into())
                     } else {
                         self.read_word()
                     }
                 }
                 c if c.is_whitespace() => {
-                    return if let Some(t) = parse_number(self.slice()) {
+                    return if let Some(t) = parse_number(self.slice(), None) {
                         Ok(t.into())
                     } else {
                         self.read_word()
@@ -354,7 +354,7 @@ impl<'a> Lexer<'a> {
                 _ => return self.read_word(),
             }
         }
-        match parse_number(self.slice()) {
+        match parse_number(self.slice(), None) {
             Some(n) => Ok(n.into()),
             None => self.read_word(),
         }
@@ -849,13 +849,13 @@ fn parse_real(s: &str, radix: u32) -> Option<RealLiteral> {
     }
 }
 
-fn parse_number(s: &str) -> Option<NumberLiteral> {
+pub fn parse_number(s: &str, radix: Option<u32>) -> Option<NumberLiteral> {
     let (s, radix) = match s.get(0..2) {
         Some("#x" | "#X") => (&s[2..], 16),
         Some("#d" | "#D") => (&s[2..], 10),
         Some("#o" | "#O") => (&s[2..], 8),
         Some("#b" | "#B") => (&s[2..], 2),
-        _ => (s, 10),
+        _ => (s, radix.unwrap_or(10)),
     };
 
     match split_into_complex(s)?.as_slice() {


### PR DESCRIPTION
instead of essentially calling `eval`, just call the `parse_number` in `steel-parser::lexer`, with an optional radix. this also has the upside of fixing most of the parsing inconsistencies essentially for free.

before:
![image](https://github.com/user-attachments/assets/aabc6f49-5807-4ebe-94cc-57491f6f75c7)

after:
![image](https://github.com/user-attachments/assets/37b9e5bb-1a3f-4678-8ba4-9daa86e6c814)

this still leaves `number->string` in need of a serious overhaul, but i've been working on that too.
