### PR TITLE
support parsing numbers without the integer part

### DIFF
--- a/crates/steel-parser/src/lexer.rs
+++ b/crates/steel-parser/src/lexer.rs
@@ -718,7 +718,7 @@ impl<'a> Iterator for Lexer<'a> {
                     Some(Ok(TokenType::Unquote))
                 }
             }
-            Some('+') | Some('-') => {
+            Some('+') | Some('-') | Some('.') => {
                 self.eat();
                 Some(self.read_number())
             }
@@ -1340,6 +1340,7 @@ mod lexer_tests {
                 1/4.0
                 1//4
                 1 / 4
+                .2
 "#,
             true,
             SourceId::none(),
@@ -1417,6 +1418,11 @@ mod lexer_tests {
                     source: "4",
                     span: Span::new(205, 206, SourceId::none()),
                 },
+                Token {
+                    ty: RealLiteral::Float(0.2).into(),
+                    source: ".2",
+                    span: Span::new(223, 225, SourceId::none())
+                }
             ]
         );
     }


### PR DESCRIPTION
this basically just means parsing `.2` as `0.2`. this is trivial, as the rust `FromStr` impl for `f64` already supports it out of the box. it was also already partially supported, as `2+.2i` parsed just fine, and the imaginary part of that is just `.2`.

specified in [r7rs](https://standards.scheme.org/official/r7rs.pdf) on page 62 in the $\<\text{decimal 10}>$ rule.