### PR TITLE
Fix dylib windows support

### DIFF
--- a/crates/cargo-steel-lib/src/lib.rs
+++ b/crates/cargo-steel-lib/src/lib.rs
@@ -106,7 +106,7 @@ pub fn run(args: Vec<String>, env_vars: Vec<(String, String)>) -> Result<(), Box
             .is_some()
         {
             for file in last.filenames {
-                if matches!(file.extension(), Some("so") | Some("dylib") | Some("lib")) {
+                if file.extension() == Some(std::env::consts::DLL_EXTENSION) {
                     println!("Found a cdylib!");
                     let filename = file.file_name().unwrap();
 

--- a/crates/steel-core/src/steel_vm/dylib.rs
+++ b/crates/steel-core/src/steel_vm/dylib.rs
@@ -123,8 +123,7 @@ impl DylibContainers {
                     for path in paths {
                         let path = path.unwrap().path();
 
-                        if path.extension().unwrap() != "so" && path.extension().unwrap() != "dylib"
-                        {
+                        if path.extension().unwrap() != std::env::consts::DLL_EXTENSION {
                             continue;
                         }
 


### PR DESCRIPTION
When attempting to use dylib on Windows platforms, the `cargo steel-lib` command incorrectly copies incompatible dependency libraries:

![企业微信截图_1744873444840](https://github.com/user-attachments/assets/772c014a-6147-4d1e-a10c-56c1f13fd787)

Even after manually placing the correct libraries in the native directory, Steel still fails to recognize them:

![企业微信截图_17448734131838](https://github.com/user-attachments/assets/041e2fa9-032e-4ce5-8e07-278c9138acd3)

So I try to Identify and modify the related code. The changes was tested on Win11 and WSL2(Arch Linux).