### PR TITLE
Implement proc macro for quasiquoting

### DIFF
--- a/crates/steel-core/src/parser/replace_idents.rs
+++ b/crates/steel-core/src/parser/replace_idents.rs
@@ -40,6 +40,25 @@ pub fn replace_identifiers(
     ReplaceExpressions::new(bindings, binding_kind, fallback_bindings).visit(expr)
 }
 
+pub fn expand_template_pair(
+    mut exprs: Vec<ExprKind>,
+    bindings_list: impl IntoIterator<Item = (InternedString, (BindingKind, ExprKind))>,
+) -> Result<Vec<ExprKind>> {
+    let mut bindings = FxHashMap::default();
+    let mut binding_kind = FxHashMap::default();
+
+    for (key, (kind, expr)) in bindings_list.into_iter() {
+        bindings.insert(key, expr);
+        binding_kind.insert(key, kind);
+    }
+
+    for expr in &mut exprs {
+        expand_template(expr, &mut bindings, &mut binding_kind)?;
+    }
+
+    Ok(exprs)
+}
+
 pub fn expand_template(
     expr: &mut ExprKind,
     bindings: &mut FxHashMap<InternedString, ExprKind>,

--- a/crates/steel-core/src/steel_vm/engine.rs
+++ b/crates/steel-core/src/steel_vm/engine.rs
@@ -79,6 +79,7 @@ use parking_lot::{
 use serde::{Deserialize, Serialize};
 use steel_gen::OpCode;
 use steel_parser::{
+    ast::List,
     parser::{SourceId, SyntaxObject},
     tokens::{IntLiteral, TokenType},
 };
@@ -2445,4 +2446,21 @@ mod derive_macro_tests {
             .run(r#"(TestEnumVariants-Ignored "Hello world")"#)
             .is_err())
     }
+}
+
+#[test]
+fn test_steel_quote_macro() {
+    let foobarbaz = ExprKind::atom("foo");
+    let foobarbaz_list = ExprKind::List(List::new(vec![ExprKind::atom("foo")]));
+
+    println!(
+        "{}",
+        steel_derive::internal_steel_quote! {
+            (define bananas #foobarbaz)
+            (define x (begin @foobarbaz_list ...))
+        }
+        .unwrap()
+        .first()
+        .unwrap()
+    );
 }


### PR DESCRIPTION
Example usage:

```rust
#[test]
fn test_steel_quote_macro() {
    let foobarbaz = ExprKind::atom("foo");
    let foobarbaz_list = ExprKind::List(List::new(vec![ExprKind::atom("foo")]));

    let expanded = steel_derive::internal_steel_quote! {
        (define bananas #foobarbaz)
        (define x (begin @foobarbaz_list ...))
    }
    .unwrap();

    for expr in expanded {
        println!("{}", expr);
    }
}

```

Prints:

```
(define bananas foo)
(define x (begin foo))
```