### PR TITLE
properly implement `number->string`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2752,12 +2752,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "radix_fmt"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce082a9940a7ace2ad4a8b7d0b1eac6aa378895f18be598230c5f2284ac05426"
-
-[[package]]
 name = "radix_trie"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3473,7 +3467,6 @@ dependencies = [
  "polling 3.7.4",
  "proptest",
  "quickscope",
- "radix_fmt",
  "rand 0.9.0",
  "serde",
  "serde_json",

--- a/crates/steel-core/Cargo.toml
+++ b/crates/steel-core/Cargo.toml
@@ -51,7 +51,6 @@ num-bigint = "0.4.6"
 num-rational = "0.4.2"
 num-traits = "0.2.19"
 num-integer = "0.1.46"
-radix_fmt = "1.0.0"
 
 # For structs
 smallvec = { version = "1.13.0" }

--- a/crates/steel-core/src/rvals.rs
+++ b/crates/steel-core/src/rvals.rs
@@ -1352,7 +1352,7 @@ impl SteelComplex {
     }
 
     /// Returns `true` if the imaginary part is negative.
-    fn imaginary_is_negative(&self) -> bool {
+    pub(crate) fn imaginary_is_negative(&self) -> bool {
         match &self.im {
             NumV(x) => x.is_negative(),
             IntV(x) => x.is_negative(),
@@ -1363,7 +1363,7 @@ impl SteelComplex {
         }
     }
 
-    fn imaginary_is_finite(&self) -> bool {
+    pub(crate) fn imaginary_is_finite(&self) -> bool {
         match &self.im {
             NumV(x) => x.is_finite(),
             IntV(_) | Rational(_) | BigNum(_) | SteelVal::BigRational(_) => true,

--- a/crates/steel-core/src/tests/success/numbers.scm
+++ b/crates/steel-core/src/tests/success/numbers.scm
@@ -239,3 +239,17 @@
 (assert-equal! 255 (string->number "ff" 16))
 (assert-equal! 1+2i (string->number "1+10i" 2))
 (assert-equal! 1/8 (string->number "1/10" 8))
+
+(define assert-number-roundtrip!
+  (case-lambda
+    [(num str)
+     (assert-equal! num (string->number str))
+     (assert-equal! str (number->string num))]
+    [(num str radix)
+     (assert-equal! num (string->number str radix))
+     (assert-equal! str (number->string num radix))]))
+
+(assert-number-roundtrip! 255 "ff" 16)
+(assert-number-roundtrip! 1+2i "1+10i" 2)
+(assert-number-roundtrip! -16 "-20" 8)
+(assert-number-roundtrip! 10 "10")


### PR DESCRIPTION
follow-up to #360. there were a few issues previously with the `number->string` procedure:

- it could not convert rationals and complex numbers
- bigints were always printed with the radix 10, even if a radix was given
- printing negative numbers with a radix would print them as their two's complement

i have fixed all of these in this pr.

before:
![image](https://github.com/user-attachments/assets/de1fd066-f840-4607-a83e-c5cad6982ff5)

after:
![image](https://github.com/user-attachments/assets/13e22dc2-3231-4b6f-9475-363e90fd1f70)