### PR TITLE
Arity Clean Up

### DIFF
--- a/crates/steel-core/src/primitives/hashsets.rs
+++ b/crates/steel-core/src/primitives/hashsets.rs
@@ -145,10 +145,6 @@ pub fn hashset_to_immutable_vector(hashset: &SteelHashSet) -> SteelVal {
 #[steel_derive::context(name = "hashset->vector", arity = "Exact(1)")]
 pub fn hashset_to_mutable_vector(ctx: &mut VmCore, args: &[SteelVal]) -> Option<Result<SteelVal>> {
     fn hashset_to_mutable_vector_impl(ctx: &mut VmCore, args: &[SteelVal]) -> Result<SteelVal> {
-        if args.len() != 1 {
-            stop!(ArityMismatch => "hashset->vector takes 1 argument")
-        }
-
         let hashset = &args[0];
 
         if let SteelVal::HashSetV(hs) = hashset {

--- a/crates/steel-core/src/primitives/lists.rs
+++ b/crates/steel-core/src/primitives/lists.rs
@@ -497,10 +497,6 @@ pub(crate) fn cdr(arg: &mut SteelVal) -> Result<SteelVal> {
 #[steel_derive::function(name = "rest", constant = true, arity = "Exact(1)")]
 fn rest(arg: &mut SteelVal) -> Result<SteelVal> {
     if let SteelVal::ListV(mut l) = std::mem::replace(arg, SteelVal::Void) {
-        if l.is_empty() {
-            stop!(Generic => "rest expects a non empty list");
-        }
-
         match l.rest_mut() {
             Some(l) => Ok(SteelVal::ListV(l.clone())),
             None => Ok(SteelVal::ListV(l.clone())),

--- a/crates/steel-core/src/primitives/lists.rs
+++ b/crates/steel-core/src/primitives/lists.rs
@@ -310,7 +310,6 @@ macro_rules! debug_unreachable {
 #[steel_derive::native(name = "range", arity = "Range(1,2)")]
 fn range(args: &[SteelVal]) -> Result<SteelVal> {
     let (lower, upper) = match args {
-        [] => stop!(ArityMismatch => "range expected one or two arguments, got 0"),
         [SteelVal::IntV(upper)] => (0, *upper),
         [SteelVal::IntV(lower), SteelVal::IntV(upper)] => (*lower, *upper),
         [invalid] | [SteelVal::IntV(_), invalid] | [invalid, _] => {
@@ -427,8 +426,6 @@ pub(crate) fn car(list: &SteelVal) -> Result<SteelVal> {
 // Optimistic check to see if the rest is null before making an allocation
 #[steel_derive::native(name = "cdr-null?", constant = true, arity = "Exact(1)")]
 fn cdr_is_null(args: &[SteelVal]) -> Result<SteelVal> {
-    arity_check!(cdr_is_null, args, 1);
-
     match &args[0] {
         SteelVal::ListV(l) => {
             if l.is_empty() {

--- a/crates/steel-core/src/primitives/numbers.rs
+++ b/crates/steel-core/src/primitives/numbers.rs
@@ -1444,12 +1444,8 @@ fn atan2(x: &SteelVal, y: &SteelVal) -> Result<SteelVal> {
 /// > (log 100 10) ;; => 2
 /// > (log 27 3) ;; => 3
 /// ```
-#[steel_derive::native(name = "log", arity = "AtLeast(1)")]
+#[steel_derive::native(name = "log", arity = "Range(1,2)")]
 fn log(args: &[SteelVal]) -> Result<SteelVal> {
-    if args.len() > 2 {
-        stop!(ArityMismatch => "log expects one or two arguments, found: {}", args.len());
-    }
-
     let first = &args[0];
     let base = args
         .get(1)
@@ -1602,9 +1598,6 @@ pub fn odd(arg: &SteelVal) -> Result<SteelVal> {
 /// ```
 #[steel_derive::native(name = "f+", constant = true, arity = "AtLeast(1)")]
 pub fn float_add(args: &[SteelVal]) -> Result<SteelVal> {
-    if args.is_empty() {
-        stop!(ArityMismatch => "f+ requires at least one argument")
-    }
     let mut sum = 0.0;
 
     for arg in args {

--- a/crates/steel-core/src/primitives/numbers.rs
+++ b/crates/steel-core/src/primitives/numbers.rs
@@ -373,12 +373,9 @@ pub fn multiply_primitive(args: &[SteelVal]) -> Result<SteelVal> {
 /// ```
 #[steel_derive::native(name = "quotient", constant = true, arity = "Exact(2)")]
 pub fn quotient(args: &[SteelVal]) -> Result<SteelVal> {
-    match &args {
-        [l, r] => match (l, r) {
-            (SteelVal::IntV(l), SteelVal::IntV(r)) => (l / r).into_steelval(),
-            _ => steelerr!(TypeMismatch => "quotient only supports integers"),
-        },
-        _ => steelerr!(ArityMismatch => "quotient requires 2 arguments"),
+    match (&args[0], &args[1]) {
+        (SteelVal::IntV(l), SteelVal::IntV(r)) => (l / r).into_steelval(),
+        _ => steelerr!(TypeMismatch => "quotient only supports integers"),
     }
 }
 
@@ -399,12 +396,9 @@ pub fn quotient(args: &[SteelVal]) -> Result<SteelVal> {
 /// ```
 #[steel_derive::native(name = "modulo", constant = true, arity = "Exact(2)")]
 pub fn modulo(args: &[SteelVal]) -> Result<SteelVal> {
-    match &args {
-        [l, r] => match (l, r) {
-            (SteelVal::IntV(l), SteelVal::IntV(r)) => ((l % r + r) % r).into_steelval(),
-            _ => steelerr!(TypeMismatch => "modulo only supports integers"),
-        },
-        _ => steelerr!(ArityMismatch => "modulo requires 2 arguments"),
+    match (&args[0], &args[1]) {
+        (SteelVal::IntV(l), SteelVal::IntV(r)) => ((l % r + r) % r).into_steelval(),
+        _ => steelerr!(TypeMismatch => "modulo only supports integers"),
     }
 }
 
@@ -425,12 +419,9 @@ pub fn modulo(args: &[SteelVal]) -> Result<SteelVal> {
 /// ```
 #[steel_derive::native(name = "remainder", constant = true, arity = "Exact(2)")]
 pub fn remainder(args: &[SteelVal]) -> Result<SteelVal> {
-    match &args {
-        [l, r] => match (l, r) {
-            (SteelVal::IntV(l), SteelVal::IntV(r)) => (l % r).into_steelval(),
-            _ => steelerr!(TypeMismatch => "remainder only supports integers"),
-        },
-        _ => steelerr!(ArityMismatch => "remainder requires 2 arguments"),
+    match (&args[0], &args[1]) {
+        (SteelVal::IntV(l), SteelVal::IntV(r)) => (l % r).into_steelval(),
+        _ => steelerr!(TypeMismatch => "remainder only supports integers"),
     }
 }
 
@@ -1523,18 +1514,15 @@ where
 /// ```
 #[steel_derive::native(name = "arithmetic-shift", constant = true, arity = "Exact(2)")]
 pub fn arithmetic_shift(args: &[SteelVal]) -> Result<SteelVal> {
-    match &args {
-        [n, m] => match (n, m) {
-            (SteelVal::IntV(n), SteelVal::IntV(m)) => {
-                if *m >= 0 {
-                    Ok(SteelVal::IntV(n << m))
-                } else {
-                    Ok(SteelVal::IntV(n >> -m))
-                }
+    match (&args[0], &args[1]) {
+        (SteelVal::IntV(n), SteelVal::IntV(m)) => {
+            if *m >= 0 {
+                Ok(SteelVal::IntV(n << m))
+            } else {
+                Ok(SteelVal::IntV(n >> -m))
             }
-            _ => stop!(TypeMismatch => "arithmetic-shift expected 2 integers"),
-        },
-        _ => stop!(ArityMismatch => "arithmetic-shift takes 2 arguments"),
+        }
+        _ => stop!(TypeMismatch => "arithmetic-shift expected 2 integers"),
     }
 }
 

--- a/crates/steel-core/src/primitives/vectors.rs
+++ b/crates/steel-core/src/primitives/vectors.rs
@@ -1008,27 +1008,16 @@ pub fn vec_length(v: Either<&SteelVector, &HeapRef<Vec<SteelVal>>>) -> SteelVal 
 /// ```
 #[steel_derive::native(name = "range-vec", constant = true, arity = "Exact(2)")]
 pub fn vec_range(args: &[SteelVal]) -> Result<SteelVal> {
-    if args.len() != 2 {
-        stop!(ArityMismatch => "range takes two arguments");
-    }
-    let mut args = args.iter();
-    match (args.next(), args.next()) {
-        (Some(elem), Some(lst)) => {
-            if let (IntV(lower), IntV(upper)) = (elem, lst) {
-                Ok(SteelVal::VectorV(
-                    Gc::new(
-                        (*lower as usize..*upper as usize)
-                            .into_iter()
-                            .map(|x| SteelVal::IntV(x as isize))
-                            .collect::<Vector<_>>(),
-                    )
-                    .into(),
-                ))
-            } else {
-                stop!(TypeMismatch => "range expected number")
-            }
-        }
-        _ => stop!(ArityMismatch => "range takes two arguments"),
+    match (&args[0], &args[1]) {
+        (SteelVal::IntV(lower), SteelVal::IntV(upper)) => Ok(SteelVal::VectorV(
+            Gc::new(
+                (*lower as usize..*upper as usize)
+                    .map(|x| SteelVal::IntV(x as isize))
+                    .collect::<Vector<_>>(),
+            )
+            .into(),
+        )),
+        _ => stop!(TypeMismatch => "range expected number"),
     }
 }
 

--- a/crates/steel-core/src/steel_vm/ffi.rs
+++ b/crates/steel-core/src/steel_vm/ffi.rs
@@ -1543,10 +1543,6 @@ pub struct HostRuntimeFunction {
 #[steel_derive::context(name = "function->ffi-function", arity = "Exact(1)")]
 pub fn function_to_ffi_function(ctx: &mut VmCore, args: &[SteelVal]) -> Option<Result<SteelVal>> {
     fn function_to_ffi_impl(ctx: &mut VmCore, args: &[SteelVal]) -> Result<SteelVal> {
-        if args.len() != 1 {
-            stop!(ArityMismatch => "function->ffi-function expects one arg, found: {}", args.len());
-        }
-
         let function = args[0].clone();
 
         if function.is_function() {

--- a/crates/steel-core/src/steel_vm/vm.rs
+++ b/crates/steel-core/src/steel_vm/vm.rs
@@ -4504,10 +4504,6 @@ pub fn call_with_exception_handler(
     ctx: &mut VmCore,
     args: &[SteelVal],
 ) -> Option<Result<SteelVal>> {
-    if args.len() != 2 {
-        builtin_stop!(ArityMismatch => format!("with-handler expects two arguments, found: {}", args.len()); ctx.current_span());
-    }
-
     let handler = args[0].clone();
     let thunk = args[1].clone();
 
@@ -4565,10 +4561,6 @@ pub fn call_cc(ctx: &mut VmCore, args: &[SteelVal]) -> Option<Result<SteelVal>> 
 
     // Roll back one because we advanced prior to entering the builtin
     ctx.ip -= 1;
-
-    if args.len() != 1 {
-        builtin_stop!(ArityMismatch => format!("call/cc expects one argument, found: {}", args.len()); ctx.current_span());
-    }
 
     let function = args[0].clone();
 
@@ -4914,10 +4906,6 @@ pub(crate) fn environment_offset(ctx: &mut VmCore, _args: &[SteelVal]) -> Option
 // back and forth will probably hamper performance significantly. That being said,
 // it is entirely at compile time, so probably _okay_
 pub(crate) fn expand_syntax_case_impl(_ctx: &mut VmCore, args: &[SteelVal]) -> Result<SteelVal> {
-    if args.len() != 3 {
-        stop!(ArityMismatch => format!("#%expand-template expected 3 arguments, found: {}", args.len()))
-    }
-
     let mut bindings: fxhash::FxHashMap<_, _> = if let SteelVal::HashMapV(h) = &args[1] {
         h.iter()
             .map(|(k, v)| match (k, v) {
@@ -5063,10 +5051,6 @@ pub(crate) fn apply(ctx: &mut VmCore, args: &[SteelVal]) -> Option<Result<SteelV
         current_instruction.op_code,
         OpCode::TAILCALL | OpCode::CALLGLOBALTAIL
     );
-
-    if args.len() != 2 {
-        builtin_stop!(ArityMismatch => "apply expected 2 arguments");
-    }
 
     let mut arg_iter = args.iter();
     let arg1 = arg_iter.next().unwrap();

--- a/crates/steel-derive/src/lib.rs
+++ b/crates/steel-derive/src/lib.rs
@@ -651,11 +651,18 @@ fn arity_code_injection(
 
     //Determines which line of code to inject into the beginning of the function as an Arity check
     let injected_code = match name {
-        "AtLeast" => quote! {
-            if #parameter_name.len() < #numb {
-                   #stop_type(ArityMismatch => "{} expects at least {} arguments, found: {}",#func_name, #numb ,#parameter_name.len());
-               }
-        },
+        "AtLeast" => {
+            // If AtLeast = 0 , then do not perform arity check, since any amount is valid
+            if numb == 0 {
+                quote! {{}}
+            } else {
+                quote! {
+                    if #parameter_name.len() < #numb {
+                        #stop_type(ArityMismatch => "{} expects at least {} arguments, found: {}", #func_name, #numb, #parameter_name.len());
+                    }
+                }
+            }
+        }
 
         "AtMost" => quote! {
             if #parameter_name.len() > #numb {


### PR DESCRIPTION
This PR deletes unnecessary arity checks, since this is provided by the derive now. In the process I cleaned up a few functions that were affected. I also added mutable vectors to the list_vec_null function. Finally I did a slight optimization when AtLeast=0, then no arity check is injected, since any amount of arguments is valid. Back to adding documentation after this me thinks.