### PR TITLE
Implement Reducer::String for into-string

### DIFF
--- a/crates/steel-core/src/tests/mod.rs
+++ b/crates/steel-core/src/tests/mod.rs
@@ -103,6 +103,7 @@ test_harness_success! {
     heap_sort,
     help,
     html_table,
+    into_string,
     letrec_mutual_recursion,
     letrec_simple_recursion,
     list_functions,

--- a/crates/steel-core/src/tests/success/into_string.scm
+++ b/crates/steel-core/src/tests/success/into_string.scm
@@ -1,0 +1,5 @@
+(assert! (equal? (transduce '("hello" " " "Steel" " " "transducer" " " "world") (into-string))
+          "hello Steel transducer world"))
+
+(assert! (equal? (transduce (list 1 2 3/4 7.5 #\* 'hoo "ray!" #t) (into-string))
+          "123/47.5*hooray!#true"))


### PR DESCRIPTION
I wasn't completely happy with the inline `to_string` replacement, but I didn't see a better alternative for now.

BTW I'm loving transducers!