### PR TITLE
optimize a few allocations and clones out of the transducer

### DIFF
--- a/crates/steel-core/src/primitives/transducers.rs
+++ b/crates/steel-core/src/primitives/transducers.rs
@@ -124,20 +124,17 @@ pub fn transduce(ctx: &mut VmCore, args: &[SteelVal]) -> Option<Result<SteelVal>
         Err(err) => return Some(Err(err)),
     };
 
-    if let SteelVal::ReducerV(r) = &reducer {
-        // TODO get rid of this unwrap
-        // just pass a reference instead
-
+    if let SteelVal::ReducerV(reducer) = &reducer {
         if ctx.depth > 32 {
             #[cfg(feature = "stacker")]
             return stacker::maybe_grow(32 * 1024, 1024 * 1024, || {
-                Some(ctx.call_transduce(&transducers, collection.clone(), r.unwrap(), None))
+                Some(ctx.call_transduce(&transducers, collection.clone(), reducer, None))
             });
 
             #[cfg(not(feature = "stacker"))]
-            Some(ctx.call_transduce(&transducers, collection.clone(), r.unwrap(), None))
+            Some(ctx.call_transduce(&transducers, collection.clone(), reducer, None))
         } else {
-            Some(ctx.call_transduce(&transducers, collection.clone(), r.unwrap(), None))
+            Some(ctx.call_transduce(&transducers, collection.clone(), reducer, None))
         }
     } else {
         builtin_stop!(TypeMismatch => format!("transduce requires that the last argument be a reducer, found: {reducer}"); ctx.previous_span())

--- a/crates/steel-core/src/steel_vm/transducers.rs
+++ b/crates/steel-core/src/steel_vm/transducers.rs
@@ -170,7 +170,7 @@ impl<'global, 'a> VmCore<'a> {
         &mut self,
         ops: &[Transducers],
         root: SteelVal,
-        reducer: Reducer,
+        reducer: &Reducer,
         cur_inst_span: &Span,
     ) -> Result<SteelVal> {
         let vm = Rc::new(RefCell::new(self));
@@ -432,7 +432,7 @@ impl<'global, 'a> VmCore<'a> {
 
     fn into_value(
         vm_ctx: Rc<RefCell<&'global mut Self>>,
-        reducer: Reducer,
+        reducer: &Reducer,
         mut iter: impl Iterator<Item = Result<SteelVal>>,
         cur_inst_span: &Span,
     ) -> Result<SteelVal> {
@@ -468,7 +468,7 @@ impl<'global, 'a> VmCore<'a> {
                 Ok(SteelVal::IntV(iter.count().try_into().unwrap())) // TODO have proper big int
             },
             Reducer::Nth(usize) => {
-                iter.nth(usize).unwrap_or_else(|| stop!(Generic => "`nth` - index given is greater than the length of the iterator"))
+                iter.nth(*usize).unwrap_or_else(|| stop!(Generic => "`nth` - index given is greater than the length of the iterator"))
             },
             Reducer::List => iter.collect::<Result<List<_>>>().map(SteelVal::ListV),
             Reducer::Vector => vec_construct_iter(iter),

--- a/crates/steel-core/src/steel_vm/vm.rs
+++ b/crates/steel-core/src/steel_vm/vm.rs
@@ -1219,7 +1219,7 @@ pub trait VmContext {
         &mut self,
         ops: &[Transducers],
         root: SteelVal,
-        reducer: Reducer,
+        reducer: &Reducer,
         span: Option<Span>,
     ) -> Result<SteelVal>;
 }
@@ -1238,7 +1238,7 @@ impl<'a> VmContext for VmCore<'a> {
         &mut self,
         ops: &[Transducers],
         root: SteelVal,
-        reducer: Reducer,
+        reducer: &Reducer,
         span: Option<Span>,
     ) -> Result<SteelVal> {
         let span = span.unwrap_or_default();


### PR DESCRIPTION
previously the transduce function would , while it would be possible to do this with only one. this is tackled in [1a041bdd494b017141c31cdcdeb4c337dca25d27] with a `FlattenOk` enum, that either returns the `Err` or flattens the value of `Ok` into multiple `Ok`s.

the `FlattenOk` enum dispatcher was the idea of [Itertools::flatten_ok](https://docs.rs/itertools/latest/itertools/trait.Itertools.html#method.flatten_ok).

in [086faf26fdae690e44a7b20b2752b9e6054c9dfb] i save an `unwrap` (a clone out of a ref-count) and just use a reference.

both of these have fixed a `TODO` comment, which was the reason that i even started looking into these.