### PR TITLE
optimize real_literal_to_steelval and deduplicate number_literal_to_steel

### DIFF
--- a/crates/steel-core/src/compiler/code_gen.rs
+++ b/crates/steel-core/src/compiler/code_gen.rs
@@ -4,7 +4,6 @@ use super::{
         Analysis,
         CallKind::{Normal, SelfTailCall, TailCall},
     },
-    program::number_literal_to_steel,
 };
 use crate::{
     compiler::passes::analysis::IdentifierStatus::{
@@ -23,6 +22,7 @@ use crate::{
         tryfrom_visitor::TryFromExprKindForSteelVal,
         visitors::VisitorMut,
     },
+    rvals::IntoSteelVal,
     stop, SteelVal,
 };
 use smallvec::SmallVec;
@@ -55,7 +55,7 @@ fn eval_atom(t: &SyntaxObject) -> Result<SteelVal> {
 fn try_eval_atom(t: &SyntaxObject) -> Option<SteelVal> {
     match &t.ty {
         TokenType::BooleanLiteral(b) => Some((*b).into()),
-        TokenType::Number(n) => number_literal_to_steel(n).ok(),
+        TokenType::Number(n) => (&**n).into_steelval().ok(),
         TokenType::StringLiteral(s) => Some(SteelVal::StringV(s.to_string().into())),
         TokenType::CharacterLiteral(c) => Some(SteelVal::CharV(*c)),
         // TODO: Keywords shouldn't be misused as an expression - only in function calls are keywords allowed
@@ -69,7 +69,7 @@ fn try_eval_atom(t: &SyntaxObject) -> Option<SteelVal> {
 fn try_eval_atom_with_context(t: &SyntaxObject) -> Result<SteelVal> {
     match &t.ty {
         TokenType::BooleanLiteral(b) => Ok((*b).into()),
-        TokenType::Number(n) => number_literal_to_steel(n).map_err(|e| e.with_span(t.span)),
+        TokenType::Number(n) => (&**n).into_steelval().map_err(|e| e.with_span(t.span)),
         TokenType::StringLiteral(s) => Ok(SteelVal::StringV(s.clone().into())),
         TokenType::CharacterLiteral(c) => Ok(SteelVal::CharV(*c)),
         TokenType::Keyword(k) => Ok(SteelVal::SymbolV(k.clone().into())),

--- a/crates/steel-core/src/compiler/program.rs
+++ b/crates/steel-core/src/compiler/program.rs
@@ -2,8 +2,7 @@ use crate::core::instructions::u24;
 use crate::core::labels::Expr;
 use crate::gc::Shared;
 use crate::parser::span_visitor::get_span;
-use crate::primitives::numbers::make_polar;
-use crate::rvals::{Result, SteelComplex};
+use crate::rvals::Result;
 use crate::{
     compiler::constants::ConstantMap,
     core::{instructions::Instruction, opcode::OpCode},
@@ -19,12 +18,8 @@ use crate::{
     },
     rvals::IntoSteelVal,
 };
-
-use num_bigint::BigInt;
-use num_rational::{BigRational, Rational32};
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, convert::TryInto, time::SystemTime};
-use steel_parser::tokens::{IntLiteral, NumberLiteral, RealLiteral};
 
 #[cfg(feature = "profiling")]
 use std::time::Instant;
@@ -36,54 +31,11 @@ use super::{compiler::DebruijnIndicesInterner, map::SymbolMap};
 
 const _TILE_SUPER_INSTRUCTIONS: bool = true;
 
-pub fn number_literal_to_steel(n: &NumberLiteral) -> Result<SteelVal> {
-    // real_to_steel does some cloning of bignums. It may be possible to optimize this away.
-    let real_to_steel = |re: &RealLiteral| match re {
-        RealLiteral::Int(IntLiteral::Small(i)) => i.into_steelval(),
-        RealLiteral::Int(IntLiteral::Big(i)) => i.clone().into_steelval(),
-        RealLiteral::Rational(n, d) => match (n, d) {
-            (IntLiteral::Small(n), IntLiteral::Small(d)) => {
-                match (i32::try_from(*n), i32::try_from(*d)) {
-                    (Ok(n), Ok(0)) => {
-                        stop!(BadSyntax => format!("division by zero in {:?}/0", n))
-                    }
-                    (Ok(n), Ok(d)) => Rational32::new(n, d).into_steelval(),
-                    _ => BigRational::new(BigInt::from(*n), BigInt::from(*d)).into_steelval(),
-                }
-            }
-            (IntLiteral::Small(n), IntLiteral::Big(d)) => {
-                BigRational::new(BigInt::from(*n), *d.clone()).into_steelval()
-            }
-            (IntLiteral::Big(n), IntLiteral::Small(d)) => {
-                BigRational::new(*n.clone(), BigInt::from(*d)).into_steelval()
-            }
-            (IntLiteral::Big(n), IntLiteral::Big(d)) => {
-                BigRational::new(*n.clone(), *d.clone()).into_steelval()
-            }
-        },
-        RealLiteral::Float(f) => f.into_steelval(),
-    };
-    match n {
-        NumberLiteral::Real(re) => real_to_steel(re),
-        NumberLiteral::Complex(re, im) => SteelComplex {
-            re: real_to_steel(re)?,
-            im: real_to_steel(im)?,
-        }
-        .into_steelval(),
-        NumberLiteral::Polar(r, theta) => {
-            let r = real_to_steel(r)?;
-            let theta = real_to_steel(theta)?;
-
-            make_polar(&r, &theta)
-        }
-    }
-}
-
 /// Evaluates an atom expression in given environment.
 fn eval_atom(t: &SyntaxObject) -> Result<SteelVal> {
     match &t.ty {
         TokenType::BooleanLiteral(b) => Ok((*b).into()),
-        TokenType::Number(n) => number_literal_to_steel(n),
+        TokenType::Number(n) => (&**n).into_steelval(),
         TokenType::StringLiteral(s) => Ok(SteelVal::StringV(s.to_string().into())),
         TokenType::CharacterLiteral(c) => Ok(SteelVal::CharV(*c)),
         // TODO: Keywords shouldn't be misused as an expression - only in function calls are keywords allowed

--- a/crates/steel-core/src/parser/parser.rs
+++ b/crates/steel-core/src/parser/parser.rs
@@ -2,7 +2,7 @@ use crate::primitives::numbers::make_polar;
 use crate::rvals::{IntoSteelVal, SteelComplex, SteelString};
 use crate::{parser::tokens::TokenType::*, rvals::FromSteelVal};
 
-use num_rational::BigRational;
+use num_rational::{BigRational, Rational32};
 use std::borrow::Cow;
 use std::str;
 use std::sync::{Arc, Mutex};
@@ -150,7 +150,16 @@ fn real_literal_to_steelval(r: RealLiteral) -> Result<SteelVal, SteelErr> {
     match r {
         RealLiteral::Int(IntLiteral::Small(x)) => x.into_steelval(),
         RealLiteral::Int(IntLiteral::Big(x)) => x.into_steelval(),
-        RealLiteral::Rational(n, d) => BigRational::new(n.into(), d.into()).into_steelval(),
+        RealLiteral::Rational(numer, denom) => match (&numer, &denom) {
+            (IntLiteral::Small(n), IntLiteral::Small(d)) => {
+                match (i32::try_from(*n), i32::try_from(*d)) {
+                    (_, Ok(0)) => steelerr!(BadSyntax => "division by zero in {}/0", numer),
+                    (Ok(n), Ok(d)) => Rational32::new(n, d).into_steelval(),
+                    (_, _) => BigRational::new(numer.into(), denom.into()).into_steelval(),
+                }
+            }
+            (_, _) => BigRational::new(numer.into(), denom.into()).into_steelval(),
+        },
         RealLiteral::Float(f) => f.into_steelval(),
     }
 }

--- a/crates/steel-core/src/steel_vm/const_evaluation.rs
+++ b/crates/steel-core/src/steel_vm/const_evaluation.rs
@@ -1,5 +1,4 @@
-use crate::compiler::program::number_literal_to_steel;
-use crate::rvals::{Result, SteelVal};
+use crate::rvals::{IntoSteelVal, Result, SteelVal};
 use crate::{
     compiler::compiler::OptLevel,
     parser::{
@@ -292,7 +291,7 @@ impl<'a> ConstantEvaluator<'a> {
                 self.bindings.borrow_mut().get(s)
             }
             // todo!() figure out if it is ok to expand scope of eval_atom.
-            TokenType::Number(n) => number_literal_to_steel(n).ok(),
+            TokenType::Number(n) => (&**n).into_steelval().ok(),
             TokenType::StringLiteral(s) => Some(SteelVal::StringV((s.clone()).into())),
             TokenType::CharacterLiteral(c) => Some(SteelVal::CharV(*c)),
             _ => None,

--- a/crates/steel-core/src/steel_vm/engine.rs
+++ b/crates/steel-core/src/steel_vm/engine.rs
@@ -20,10 +20,7 @@ use crate::{
             intern_modules, path_to_module_name, CompiledModule, SourceModuleResolver,
             MANGLER_PREFIX, PRELUDE_WITHOUT_BASE,
         },
-        program::{
-            number_literal_to_steel, Executable, RawProgramWithSymbols,
-            SerializableRawProgramWithSymbols,
-        },
+        program::{Executable, RawProgramWithSymbols, SerializableRawProgramWithSymbols},
     },
     containers::RegisterValue,
     core::{
@@ -1561,7 +1558,7 @@ impl Engine {
         fn eval_atom(t: &SyntaxObject) -> Result<SteelVal> {
             match &t.ty {
                 TokenType::BooleanLiteral(b) => Ok((*b).into()),
-                TokenType::Number(n) => number_literal_to_steel(n),
+                TokenType::Number(n) => (&**n).into_steelval(),
                 TokenType::StringLiteral(s) => Ok(SteelVal::StringV(s.clone().into())),
                 TokenType::CharacterLiteral(c) => Ok(SteelVal::CharV(*c)),
                 // TODO: Keywords shouldn't be misused as an expression - only in function calls are keywords allowed


### PR DESCRIPTION
the `real_literal_to_steel` function was 1) eagerly allocating when converting to a `Rational` and 2) was panicking when the denominator of the `Rational` was 0, instead of returning an error.

additionally the `number_literal_to_steel` function was essentially a reimplementation of `NumberLiteral::into_steelval`. i also changed it to an `impl IntoSteelval for &NumberLiteral`, as i think that makes sense.