### PR TITLE
Fix struct arity mismatch argument count order

### DIFF
--- a/crates/steel-core/src/values/structs.rs
+++ b/crates/steel-core/src/values/structs.rs
@@ -332,8 +332,8 @@ impl UserDefinedStruct {
                 let error_message = format!(
                     "{} expected {} arguments, found {}",
                     descriptor.name().clone(),
+                    len,
                     args.len(),
-                    len
                 );
                 stop!(ArityMismatch => error_message);
             }
@@ -361,8 +361,8 @@ impl UserDefinedStruct {
                 let error_message = format!(
                     "{} expected {} arguments, found {}",
                     name.clone(),
+                    len,
                     args.len(),
-                    len
                 );
                 stop!(ArityMismatch => error_message);
             }


### PR DESCRIPTION
With this fix:
```
λ > (struct s (a b c))
λ > (s 1 2)
error[E01]: ArityMismatch
  ┌─ :1:2
1 │ (s 1 2)
  │  ^ s expected 3 arguments, found 2
```

Fixes #426