### PR TITLE
missing use in derive macro

### DIFF
--- a/crates/steel-derive/src/lib.rs
+++ b/crates/steel-derive/src/lib.rs
@@ -129,6 +129,7 @@ fn derive_steel_impl(input: DeriveInput, prefix: proc_macro2::TokenStream) -> To
                     #[doc = "Registers the struct functions with this module"]
                     fn register_type(module: &mut #prefix::steel_vm::builtin::BuiltInModule) ->
                         &mut #prefix::steel_vm::builtin::BuiltInModule {
+                        use #prefix::steel_vm::register_fn::RegisterFn;
                         #(
                             module.register_fn(#names, #values);
                         )*
@@ -331,6 +332,7 @@ fn derive_steel_impl(input: DeriveInput, prefix: proc_macro2::TokenStream) -> To
                     #[doc = "Registers the enum variant functions with this module"]
                     fn register_enum_variants(module: &mut #prefix::steel_vm::builtin::BuiltInModule) ->
                         &mut #prefix::steel_vm::builtin::BuiltInModule {
+                        use #prefix::steel_vm::register_fn::RegisterFn;
                         #(
                             module.register_fn(#names, #values);
                         )*


### PR DESCRIPTION
Hello,

Thanks for the awesome work!

While playing around with it, I encountered the tiny bug that the `Steel` derive macro generates `register_*` functions which need the trait `RegisterFn` to be in scope. This PR aims to fix that by simply importing the trait in said function.

I believe this is sufficiently hygienic. The other option would be a `#prefix::steel_vm::register_fn::RegisterFn::register_fn(...)` but I find that less clean.