### PR TITLE
Fix eqv? for string->symbol

### DIFF
--- a/crates/steel-core/src/rvals.rs
+++ b/crates/steel-core/src/rvals.rs
@@ -1773,7 +1773,7 @@ impl SteelVal {
             (Void, Void) => true,
             (StringV(l), StringV(r)) => crate::gc::Shared::ptr_eq(l, r),
             (FuncV(l), FuncV(r)) => *l as usize == *r as usize,
-            (SymbolV(l), SymbolV(r)) => crate::gc::Shared::ptr_eq(l, r),
+            (SymbolV(l), SymbolV(r)) => crate::gc::Shared::ptr_eq(l, r) || l == r,
             (SteelVal::Custom(l), SteelVal::Custom(r)) => Gc::ptr_eq(l, r),
             (HashMapV(l), HashMapV(r)) => Gc::ptr_eq(&l.0, &r.0),
             (HashSetV(l), HashSetV(r)) => Gc::ptr_eq(&l.0, &r.0),

--- a/crates/steel-core/src/tests/mod.rs
+++ b/crates/steel-core/src/tests/mod.rs
@@ -138,6 +138,7 @@ test_harness_success! {
     stack_test_with_contract,
     string_append,
     structs,
+    symbols,
     // TODO: @Matt 11/11/2023
     syntax_case,
     threads,

--- a/crates/steel-core/src/tests/success/symbols.scm
+++ b/crates/steel-core/src/tests/success/symbols.scm
@@ -1,0 +1,2 @@
+(assert! (eqv? 'abc (string->symbol "abc")))
+(assert! (eq? 'abc (string->symbol "abc")))


### PR DESCRIPTION
### Motivation

Fixes https://github.com/mattwparas/steel/issues/448


### Summary

* If pointer comparison for a symbol returns false, additionally check for value equality
* Added a test for the case mentioned in [the issue](https://github.com/mattwparas/steel/issues/448), because the behavior should also be fixed for `eq?` I provided a test for it too.