### PR TITLE
fix new rustc lints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2536,9 +2536,9 @@ dependencies = [
 
 [[package]]
 name = "onig_sys"
-version = "69.8.1"
+version = "69.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b829e3d7e9cc74c7e315ee8edb185bf4190da5acde74afd7fc59c35b1f086e7"
+checksum = "c7f86c6eef3d6df15f23bcfb6af487cbd2fed4e5581d58d5bf1f5f8b7f6727dc"
 dependencies = [
  "cc",
  "pkg-config",

--- a/crates/steel-core/src/steel_vm/builtin.rs
+++ b/crates/steel-core/src/steel_vm/builtin.rs
@@ -171,6 +171,7 @@ pub fn get_function_metadata(function: BuiltInFunctionType) -> Option<FunctionSi
 }
 
 #[derive(Copy, Clone, Hash, PartialEq, Eq)]
+#[allow(unpredictable_function_pointer_comparisons)]
 pub enum BuiltInFunctionType {
     Reference(FunctionSignature),
     Mutable(MutFunctionSignature),

--- a/crates/steel-core/src/steel_vm/ffi.rs
+++ b/crates/steel-core/src/steel_vm/ffi.rs
@@ -173,7 +173,7 @@ pub trait IntoFFIVal: Sized {
 }
 
 pub trait IntoFFIArg: Sized {
-    fn into_ffi_arg(&self) -> RResult<FFIArg, RBoxError>;
+    fn into_ffi_arg(&self) -> RResult<FFIArg<'_>, RBoxError>;
 }
 
 pub trait FromFFIArg<'a>: Sized {

--- a/crates/steel-core/src/steel_vm/vm.rs
+++ b/crates/steel-core/src/steel_vm/vm.rs
@@ -55,7 +55,7 @@ use std::io::Read as _;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use std::sync::Mutex;
-use std::{cell::RefCell, collections::HashMap, iter::Iterator, rc::Rc};
+use std::{cell::RefCell, collections::HashMap, iter::Iterator};
 
 use super::engine::EngineId;
 
@@ -189,7 +189,7 @@ fn check_sizes() {
     println!("stack frame: {:?}", std::mem::size_of::<StackFrame>());
     println!(
         "option rc steelval: {:?}",
-        std::mem::size_of::<Option<Rc<SteelVal>>>()
+        std::mem::size_of::<Option<std::rc::Rc<SteelVal>>>()
     );
     println!(
         "option box steelval: {:?}",
@@ -5253,8 +5253,9 @@ pub(crate) fn apply(ctx: &mut VmCore, args: &[SteelVal]) -> Option<Result<SteelV
 }
 
 #[derive(PartialEq, Eq, Hash, Clone, PartialOrd, Ord, Debug)]
+#[cfg(feature = "dynamic")]
 pub struct InstructionPattern {
-    pub(crate) block: Rc<[(OpCode, usize)]>,
+    pub(crate) block: std::rc::Rc<[(OpCode, usize)]>,
     pub(crate) pattern: BlockPattern,
 }
 

--- a/crates/steel-language-server/src/diagnostics.rs
+++ b/crates/steel-language-server/src/diagnostics.rs
@@ -587,6 +587,7 @@ fn function_contract(expr: &ExprKind) -> Option<steel::rvals::Result<StaticContr
 }
 
 #[derive(Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
+#[allow(unpredictable_function_pointer_comparisons)]
 pub enum TypeInfo {
     // We don't have enough information to say what this type is
     // Either, the function has come externally or it was unable to be inferred for some reason

--- a/crates/steel-parser/src/ast.rs
+++ b/crates/steel-parser/src/ast.rs
@@ -431,11 +431,11 @@ impl ExprKind {
 }
 
 pub trait ToDoc {
-    fn to_doc(&self) -> RcDoc<()>;
+    fn to_doc(&self) -> RcDoc<'_, ()>;
 }
 
 impl ToDoc for ExprKind {
-    fn to_doc(&self) -> RcDoc<()> {
+    fn to_doc(&self) -> RcDoc<'_, ()> {
         match self {
             ExprKind::Atom(a) => a.to_doc(),
             ExprKind::If(i) => i.to_doc(),
@@ -533,7 +533,7 @@ impl fmt::Display for Atom {
 }
 
 impl ToDoc for Atom {
-    fn to_doc(&self) -> RcDoc<()> {
+    fn to_doc(&self) -> RcDoc<'_, ()> {
         RcDoc::text(self.syn.ty.to_string())
     }
 }
@@ -590,7 +590,7 @@ impl fmt::Display for Let {
 }
 
 impl ToDoc for Let {
-    fn to_doc(&self) -> RcDoc<()> {
+    fn to_doc(&self) -> RcDoc<'_, ()> {
         RcDoc::text("(%plain-let")
             .append(RcDoc::space())
             .append(RcDoc::text("("))
@@ -646,7 +646,7 @@ impl fmt::Display for Set {
 }
 
 impl ToDoc for Set {
-    fn to_doc(&self) -> RcDoc<()> {
+    fn to_doc(&self) -> RcDoc<'_, ()> {
         RcDoc::text("(set!")
             .append(RcDoc::space())
             .append(self.variable.to_doc())
@@ -673,7 +673,7 @@ pub struct If {
 }
 
 impl ToDoc for If {
-    fn to_doc(&self) -> RcDoc<()> {
+    fn to_doc(&self) -> RcDoc<'_, ()> {
         RcDoc::text("(if")
             .append(RcDoc::space())
             .append(self.test_expr.to_doc())
@@ -735,7 +735,7 @@ impl fmt::Display for Define {
 }
 
 impl ToDoc for Define {
-    fn to_doc(&self) -> RcDoc<()> {
+    fn to_doc(&self) -> RcDoc<'_, ()> {
         RcDoc::text("(define")
             .append(RcDoc::space())
             .append(self.name.to_doc())
@@ -822,7 +822,7 @@ impl fmt::Display for LambdaFunction {
 }
 
 impl ToDoc for LambdaFunction {
-    fn to_doc(&self) -> RcDoc<()> {
+    fn to_doc(&self) -> RcDoc<'_, ()> {
         if self.rest && self.args.len() == 1 {
             RcDoc::text("(λ")
                 .append(RcDoc::space())
@@ -922,7 +922,7 @@ impl fmt::Display for Begin {
 }
 
 impl ToDoc for Begin {
-    fn to_doc(&self) -> RcDoc<()> {
+    fn to_doc(&self) -> RcDoc<'_, ()> {
         RcDoc::text("(begin")
             .append(RcDoc::line())
             .nest(5)
@@ -962,7 +962,7 @@ impl Return {
 }
 
 impl ToDoc for Return {
-    fn to_doc(&self) -> RcDoc<()> {
+    fn to_doc(&self) -> RcDoc<'_, ()> {
         RcDoc::text("(return")
             .append(RcDoc::line())
             .append(self.expr.to_doc())
@@ -996,7 +996,7 @@ impl Require {
 }
 
 impl ToDoc for Require {
-    fn to_doc(&self) -> RcDoc<()> {
+    fn to_doc(&self) -> RcDoc<'_, ()> {
         RcDoc::text("(require")
             .append(RcDoc::line())
             .append(
@@ -1069,7 +1069,7 @@ impl fmt::Display for Vector {
 }
 
 impl ToDoc for Vector {
-    fn to_doc(&self) -> RcDoc<()> {
+    fn to_doc(&self) -> RcDoc<'_, ()> {
         RcDoc::text(self.prefix().as_str())
             .append("(")
             .append(
@@ -1321,7 +1321,7 @@ impl List {
 }
 
 impl ToDoc for List {
-    fn to_doc(&self) -> RcDoc<()> {
+    fn to_doc(&self) -> RcDoc<'_, ()> {
         if let Some(func) = self.first_func().filter(|_| !self.improper) {
             let mut args_iter = self.args.iter();
             args_iter.next();
@@ -1425,7 +1425,7 @@ impl Quote {
 }
 
 impl ToDoc for Quote {
-    fn to_doc(&self) -> RcDoc<()> {
+    fn to_doc(&self) -> RcDoc<'_, ()> {
         RcDoc::text("(quote")
             .append(RcDoc::line())
             .append(self.expr.to_doc())
@@ -1462,7 +1462,7 @@ impl fmt::Display for Macro {
 }
 
 impl ToDoc for Macro {
-    fn to_doc(&self) -> RcDoc<()> {
+    fn to_doc(&self) -> RcDoc<'_, ()> {
         RcDoc::text("(define-syntax")
             .append(RcDoc::line())
             .append(self.name.to_doc())
@@ -1521,7 +1521,7 @@ impl fmt::Display for SyntaxRules {
 }
 
 impl ToDoc for SyntaxRules {
-    fn to_doc(&self) -> RcDoc<()> {
+    fn to_doc(&self) -> RcDoc<'_, ()> {
         RcDoc::text("(syntax-rules")
             .append(RcDoc::line())
             .append(RcDoc::text("("))
@@ -1561,7 +1561,7 @@ impl PatternPair {
 }
 
 impl ToDoc for PatternPair {
-    fn to_doc(&self) -> RcDoc<()> {
+    fn to_doc(&self) -> RcDoc<'_, ()> {
         RcDoc::text("[")
             .append(self.pattern.to_doc())
             .append(RcDoc::line())

--- a/crates/steel-parser/src/lexer.rs
+++ b/crates/steel-parser/src/lexer.rs
@@ -890,7 +890,7 @@ mod lexer_tests {
     use crate::tokens::{IntLiteral, TokenType::*};
     use pretty_assertions::assert_eq;
 
-    fn identifier(ident: &str) -> TokenType<Cow<str>> {
+    fn identifier(ident: &str) -> TokenType<Cow<'_, str>> {
         Identifier(ident.into())
     }
 


### PR DESCRIPTION
rust beta (i.e. the next stable release) introduces two more rustc lints, mismatched-lifetime-syntaxes:

```
warning: hiding a lifetime that's elided elsewhere is confusing
   --> crates/steel-core/src/steel_vm/ffi.rs:176:21
    |
176 |     fn into_ffi_arg(&self) -> RResult<FFIArg, RBoxError>;
    |                     ^^^^^             ------ the same lifetime is hidden here
    |                     |
    |                     the lifetime is elided here
    |
    = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
    = note: `#[warn(mismatched_lifetime_syntaxes)]` on by default
help: use `'_` for type paths
    |
176 |     fn into_ffi_arg(&self) -> RResult<FFIArg<'_>, RBoxError>;
    |                                             ++++
```

for that lint, i just went through every single warning and just fixed them.

and unpredictable_function_pointer_comparisons:

```
warning: function pointer comparisons do not produce meaningful results since their addresses are not guaranteed to be unique
   --> crates/steel-core/src/steel_vm/builtin.rs:175:15
    |
173 | #[derive(Copy, Clone, Hash, PartialEq, Eq)]
    |                             --------- in this derive macro expansion
174 | pub enum BuiltInFunctionType {
175 |     Reference(FunctionSignature),
    |               ^^^^^^^^^^^^^^^^^
    |
    = note: the address of the same function can vary between different codegen units
    = note: furthermore, different functions could have the same address after being merged together
    = note: for more information visit <https://doc.rust-lang.org/nightly/core/ptr/fn.fn_addr_eq.html>
    = note: `#[warn(unpredictable_function_pointer_comparisons)]` on by default
```

there was not much i could do for that lint, so i just `#[allow]`ed it. the official suggestion is to be more explicit and use `std::ptr::fn_addr_eq` for more clarity, but i don't think manually writing the `PartialEq` impl to use that function is better. also `fn_addr_eq` is only available in rust >= 1.85.