### PR TITLE
fix colorized output in display

### DIFF
--- a/crates/steel-core/src/rvals.rs
+++ b/crates/steel-core/src/rvals.rs
@@ -2459,9 +2459,17 @@ impl PartialOrd for SteelVal {
     }
 }
 
+pub(crate) struct SteelValDisplay<'a>(pub(crate) &'a SteelVal);
+
+impl<'a> fmt::Display for SteelValDisplay<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        CycleDetector::detect_and_display_cycles(&self.0, f, false)
+    }
+}
+
 impl fmt::Display for SteelVal {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        CycleDetector::detect_and_display_cycles(self, f)
+        CycleDetector::detect_and_display_cycles(self, f, true)
     }
 }
 
@@ -2475,7 +2483,7 @@ impl fmt::Debug for SteelVal {
         };
         // display_helper(self, f)
 
-        CycleDetector::detect_and_display_cycles(self, f)
+        CycleDetector::detect_and_display_cycles(self, f, true)
     }
 }
 

--- a/crates/steel-core/src/scheme/modules/parameters.scm
+++ b/crates/steel-core/src/scheme/modules/parameters.scm
@@ -96,7 +96,7 @@
 (define current-error-port (make-parameter (#%default-error-port)))
 
 (define (simple-display x)
-  (#%raw-write-string x (current-output-port)))
+  (#%raw-display x (current-output-port)))
 
 (define write-string #%raw-write-string)
 


### PR DESCRIPTION
I think https://github.com/mattwparas/steel/pull/339 broke colorized output. Current behavior is:
```
(display #\u{1b})

=> #\u001b
```

which is incorrect, as `display` should not print external representations.