### PR TITLE
fix strange behaviour of (min) and (max)

### DIFF
--- a/crates/steel-core/src/scheme/stdlib.scm
+++ b/crates/steel-core/src/scheme/stdlib.scm
@@ -563,10 +563,11 @@
 (define fold (lambda (f a l) (foldl f a l)))
 (define reduce (lambda (f a l) (fold f a l)))
 
-(define max (lambda (x . num-list) (fold (lambda (y z) (if (> y z) y z)) x num-list)))
+(define (max x . rest)
+  (fold (lambda (y z) (if (> y z) y z)) x rest))
 
-(define min
-  (lambda (x . num-list) (fold (lambda (y z) (if (< y z) y z)) x num-list)))
+(define (min x . rest)
+  (fold (lambda (y z) (if (< y z) y z)) x rest))
 
 (define mem-helper
   (lambda (pred op) (lambda (acc next) (if (and (not acc) (pred (op next))) next acc))))

--- a/crates/steel-core/src/scheme/stdlib.scm
+++ b/crates/steel-core/src/scheme/stdlib.scm
@@ -563,9 +563,10 @@
 (define fold (lambda (f a l) (foldl f a l)))
 (define reduce (lambda (f a l) (fold f a l)))
 
-(define max (lambda (x . num-list) (fold (lambda (y z) (if (> y z) y z)) x (cons 0 num-list))))
+(define max (lambda (x . num-list) (fold (lambda (y z) (if (> y z) y z)) x num-list)))
+
 (define min
-  (lambda (x . num-list) (fold (lambda (y z) (if (< y z) y z)) x (cons 536870911 num-list))))
+  (lambda (x . num-list) (fold (lambda (y z) (if (< y z) y z)) x num-list)))
 
 (define mem-helper
   (lambda (pred op) (lambda (acc next) (if (and (not acc) (pred (op next))) next acc))))


### PR DESCRIPTION
before:

```
λ > (min +inf.0)
=> 536870911
λ > (max -1)
=> 0
```

after:

```
λ > (min +inf.0)
=> +inf.0
λ > (max -1)
=> -1
```

racket:

```
> (max -1)
-1
> (min +inf.0)
+inf.0
```