### PR TITLE
return a unicode replacement character instead of erroring in read-char

### DIFF
--- a/crates/steel-core/src/values/port.rs
+++ b/crates/steel-core/src/values/port.rs
@@ -208,7 +208,9 @@ impl SteelPortRepr {
                     if i == 0 {
                         return Ok(MaybeBlocking::Nonblocking(None));
                     } else {
-                        stop!(ConversionError => "unable to decode character, found {:?}", &buf[0..=i]);
+                        return Ok(MaybeBlocking::Nonblocking(Some(
+                            char::REPLACEMENT_CHARACTER,
+                        )));
                     }
                 }
                 MaybeBlocking::WouldBlock => return Ok(MaybeBlocking::WouldBlock),
@@ -219,13 +221,17 @@ impl SteelPortRepr {
             match std::str::from_utf8(&buf[0..=i]) {
                 Ok(s) => return Ok(MaybeBlocking::Nonblocking(s.chars().next())),
                 Err(err) if err.error_len().is_some() => {
-                    stop!(ConversionError => "unable to decode character, found {:?}", &buf[0..=i]);
+                    return Ok(MaybeBlocking::Nonblocking(Some(
+                        char::REPLACEMENT_CHARACTER,
+                    )));
                 }
                 _ => {}
             }
         }
 
-        stop!(ConversionError => "unable to decode character, found {:?}", buf);
+        Ok(MaybeBlocking::Nonblocking(Some(
+            char::REPLACEMENT_CHARACTER,
+        )))
     }
 
     pub fn read_bytes_amt(&mut self, buf: &mut [u8]) -> Result<MaybeBlocking<(usize, bool)>> {


### PR DESCRIPTION
this seems to be what most other scheme interpreters, at least the ones, that i have tested this with (racket, mit-scheme, guile, tinyscheme), do. none that i could find return an error, and to.

both r5rs and r7rs are pretty vague about it, only specifying, that `read-char` "returns the next character," but given, that it specifically isn't mentioned, that it is "an error," which both documents frequently do, i think it should not return an error.

```
$ racket
> (define ip (open-input-string "λ"))
> (read-byte ip)
206
> (read-char ip)
#\�

$ steel
λ > (define ip (open-input-string "λ"))
λ > (read-byte ip)
=> 206
λ > (read-char ip)
error[E07]: ConversionError
  ┌─ :1:2
  │
1 │ (read-char ip)
  │  ^^^^^^^^^ unable to decode character, found [187]
```