### PR TITLE
 fix char display in the repl again 

### DIFF
--- a/crates/steel-core/src/primitives/ports.rs
+++ b/crates/steel-core/src/primitives/ports.rs
@@ -3,9 +3,7 @@ use std::fs::OpenOptions;
 use crate::gc::shared::ShareableMut;
 use crate::gc::Gc;
 use crate::primitives::lists::plist_get_impl;
-use crate::rvals::{
-    FromSteelVal, RestArgsIter, Result, SteelByteVector, SteelString, SteelVal, SteelValDisplay,
-};
+use crate::rvals::{FromSteelVal, RestArgsIter, Result, SteelByteVector, SteelString, SteelVal};
 use crate::steel_vm::builtin::BuiltInModule;
 use crate::values::port::{would_block, SteelPort, SteelPortRepr, WOULD_BLOCK_OBJECT};
 use crate::values::structs::{make_struct_singleton, StructTypeDescriptor};
@@ -379,7 +377,7 @@ pub fn write_line(port: &SteelPort, line: &SteelVal) -> Result<SteelVal> {
 #[function(name = "#%raw-write")]
 pub fn write(line: &SteelVal, rest: RestArgsIter<&SteelPort>) -> Result<SteelVal> {
     let port = output_args(rest)?;
-    let line = line.to_string();
+    let line = format!("{:?}", line);
     let res = port.write(line.as_str().as_bytes());
 
     if res.is_ok() {
@@ -392,7 +390,7 @@ pub fn write(line: &SteelVal, rest: RestArgsIter<&SteelPort>) -> Result<SteelVal
 #[function(name = "#%raw-display")]
 pub fn display(line: &SteelVal, rest: RestArgsIter<&SteelPort>) -> Result<SteelVal> {
     let port = output_args(rest)?;
-    let line = SteelValDisplay(line).to_string();
+    let line = line.to_string();
     let res = port.write(line.as_str().as_bytes());
 
     if res.is_ok() {

--- a/crates/steel-core/src/rvals.rs
+++ b/crates/steel-core/src/rvals.rs
@@ -2480,17 +2480,9 @@ impl PartialOrd for SteelVal {
     }
 }
 
-pub(crate) struct SteelValDisplay<'a>(pub(crate) &'a SteelVal);
-
-impl<'a> fmt::Display for SteelValDisplay<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        CycleDetector::detect_and_display_cycles(&self.0, f, false)
-    }
-}
-
 impl fmt::Display for SteelVal {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        CycleDetector::detect_and_display_cycles(self, f, true)
+        CycleDetector::detect_and_display_cycles(self, f, false)
     }
 }
 
@@ -2502,7 +2494,6 @@ impl fmt::Debug for SteelVal {
             SymbolV(_) | ListV(_) | VectorV(_) => write!(f, "'")?,
             _ => (),
         };
-        // display_helper(self, f)
 
         CycleDetector::detect_and_display_cycles(self, f, true)
     }

--- a/crates/steel-core/src/scheme/print.scm
+++ b/crates/steel-core/src/scheme/print.scm
@@ -29,10 +29,6 @@
                 (newline)))
             (#%private-cycle-collector-values cycle-collector))
 
-  ;; Symbols are funny
-  (when (or (symbol? obj) (list? obj))
-    (simple-display "'"))
-
   (#%top-level-print obj cycle-collector))
 
 (define display

--- a/crates/steel-core/src/steel_vm/meta.rs
+++ b/crates/steel-core/src/steel_vm/meta.rs
@@ -84,7 +84,7 @@ impl EngineWrapper {
             SteelVal::ListV(list) => {
                 let values = list
                     .iter()
-                    .map(|x| x.to_string())
+                    .map(|x| format!("{:?}", x))
                     .map(|x| {
                         self.0.compile_and_run_raw_program(Cow::from(
                             x.trim_start_matches('\'').to_string(),

--- a/crates/steel-repl/src/repl.rs
+++ b/crates/steel-repl/src/repl.rs
@@ -82,14 +82,7 @@ fn finish_load_or_interrupt(vm: &mut Engine, exprs: String, path: PathBuf) {
     match res {
         Ok(r) => r.into_iter().for_each(|x| match x {
             SteelVal::Void => {}
-            SteelVal::StringV(s) => {
-                println!("{} {:?}", "=>".bright_blue().bold(), s);
-            }
-            _ => {
-                print!("{} ", "=>".bright_blue().bold());
-                vm.call_function_by_name_with_args("displayln", vec![x])
-                    .unwrap();
-            }
+            _ => println!("{} {}", "=>".bright_blue().bold(), x),
         }),
         Err(e) => {
             vm.raise_error(e);
@@ -118,14 +111,7 @@ fn finish_or_interrupt(vm: &mut Engine, line: String) {
 
         match value {
             SteelVal::Void => {}
-            SteelVal::StringV(s) => {
-                println!("{} {:?}", "=>".bright_blue().bold(), s);
-            }
-            _ => {
-                print!("{} ", "=>".bright_blue().bold());
-                vm.call_function_by_name_with_args("displayln", vec![value])
-                    .unwrap();
-            }
+            _ => println!("{} {}", "=>".bright_blue().bold(), value),
         }
     }
 }

--- a/crates/steel-repl/src/repl.rs
+++ b/crates/steel-repl/src/repl.rs
@@ -82,7 +82,7 @@ fn finish_load_or_interrupt(vm: &mut Engine, exprs: String, path: PathBuf) {
     match res {
         Ok(r) => r.into_iter().for_each(|x| match x {
             SteelVal::Void => {}
-            _ => println!("{} {}", "=>".bright_blue().bold(), x),
+            _ => println!("{} {:?}", "=>".bright_blue().bold(), x),
         }),
         Err(e) => {
             vm.raise_error(e);
@@ -111,7 +111,7 @@ fn finish_or_interrupt(vm: &mut Engine, line: String) {
 
         match value {
             SteelVal::Void => {}
-            _ => println!("{} {}", "=>".bright_blue().bold(), value),
+            _ => println!("{} {:?}", "=>".bright_blue().bold(), value),
         }
     }
 }


### PR DESCRIPTION
i "fixed" the repl char display in #339, which accidentally broke the `(display)` functions, which was then fixed in #470, ... which broke the char display in the repl again, as that was just calling `(displayln)` instead of the rust `Display` impl...

this contains some small, additional cleanups that i noticed while attempting to fix the char printing, specifically removing the `SteelValDisplay` from #470 and just moving that into the regular `Display` impl, while still having the `Debug` impl for how the repl and the `write` function wants the value.

here's a quick demo:

<img width="1099" height="696" alt="image" src="https://github.com/user-attachments/assets/44c763d2-b839-4a80-b356-8651e991e9f8" />
