### PR TITLE
properly strip shebangs with non-ascii characters

### DIFF
--- a/crates/steel-parser/src/lexer.rs
+++ b/crates/steel-parser/src/lexer.rs
@@ -535,20 +535,13 @@ impl<'b, 'a: 'b> IdentBuffer<'b, 'a> {
     }
 }
 
-fn strip_shebang_line(input: &str) -> (&str, usize, usize) {
+fn strip_shebang_line(input: &str) -> (usize, usize) {
     if input.starts_with("#!") {
-        let stripped = input.trim_start_matches("#!");
-        let result = match stripped.char_indices().find(|x| x.1 == '\n') {
-            Some((pos, _)) => &stripped[pos..],
-            None => "",
-        };
-
-        let original = input.len();
-        let new = result.len();
-
-        (result, original - new, input.len() - result.len())
+        // split is guaranteed to yield at least one element
+        let shebang = input.split('\n').next().unwrap();
+        (shebang.chars().count(), shebang.len())
     } else {
-        (input, 0, 0)
+        (0, 0)
     }
 }
 
@@ -576,7 +569,7 @@ pub struct TokenStream<'a> {
 
 impl<'a> TokenStream<'a> {
     pub fn new(input: &'a str, skip_comments: bool, source_id: Option<SourceId>) -> Self {
-        let (_, char_offset, bytes_offset) = strip_shebang_line(input);
+        let (char_offset, bytes_offset) = strip_shebang_line(input);
 
         let mut res = Self {
             lexer: Lexer::new(input),


### PR DESCRIPTION
consider the following scheme code:

```scheme
#!/usr/bin/env λλλλλλλλλλ

(displayln 'test)
```

trying to execute that with `steel` will result in the following error:

```
$ steel test.scm
error[E09]: Parse
  ┌─ /home/may/projects/steel/.tmp/shebang.scm:3:7
  │
3 │ (displayln 'test)
  │       ^ Parse: Unexpected character: ')'
```

since it would previously incorrectly count the chars as `input.len() - result.len()`, which is actually bytes. this pr fixes that.

a side note on performance:

it might look like this does more work, as it counts the chars in a second pass, seperately from the first `find`, but rust actually optimizes this quite well: the first find is optimized into a memchr and optimizes out the unwrap [^1] and `chars().count()` is special-cased, as you can essentially just count all the bytes that don't start with `0b10` and don't have to bother with decoding anything [^2].

so it's more like converting a single unicode-decoding pass over the input into two passes, that only work on the individual bytes.

[^1]: https://godbolt.org/z/3P4dYe68j
[^2]: https://github.com/rust-lang/rust/blob/b41634205b549a62cfa55363d1e00c4143d30033/library/core/src/str/count.rs#L27-L37