### PR TITLE
add missing ports to read-all-str and read-line, slightly improve errors

### DIFF
--- a/crates/steel-core/src/values/port.rs
+++ b/crates/steel-core/src/values/port.rs
@@ -160,16 +160,11 @@ impl SteelPortRepr {
             SteelPortRepr::FileInput(_, br) => port_read_str_fn!(br, read_line),
             SteelPortRepr::StdInput(br) => port_read_str_fn!(br, read_line),
             SteelPortRepr::StringInput(s) => port_read_str_fn!(s, read_line),
-
-            SteelPortRepr::ChildStdOutput(br) => {
-                port_read_str_fn!(br, read_line)
-            }
-
+            SteelPortRepr::ChildStdOutput(br) => port_read_str_fn!(br, read_line),
+            SteelPortRepr::ChildStdError(br) => port_read_str_fn!(br, read_line),
             SteelPortRepr::DynReader(br) => port_read_str_fn!(br, read_line),
-
-            // SteelPort::ChildStdOutput(br) => port_read_str_fn!(br, read_line),
             // FIXME: fix this and the functions below
-            _x => stop!(Generic => "read-line"),
+            _ => stop!(TypeMismatch => "expected an input port"),
         }
     }
 
@@ -189,11 +184,11 @@ impl SteelPortRepr {
         match self {
             SteelPortRepr::FileInput(_, br) => port_read_str_fn!(br, read_to_string),
             SteelPortRepr::StdInput(br) => port_read_str_fn!(br, read_to_string),
+            SteelPortRepr::StringInput(s) => port_read_str_fn!(s, read_to_string),
             SteelPortRepr::ChildStdOutput(br) => port_read_str_fn!(br, read_to_string),
             SteelPortRepr::ChildStdError(br) => port_read_str_fn!(br, read_to_string),
             SteelPortRepr::DynReader(br) => port_read_str_fn!(br, read_to_string),
-            SteelPortRepr::StringInput(br) => port_read_str_fn!(br, read_to_string),
-            x => stop!(Generic => "read-all-str: {:?}", x),
+            _ => stop!(TypeMismatch => "expected an input port"),
         }
     }
 


### PR DESCRIPTION
previously:

```
λ > (define ip (open-input-string "test string"))
λ > (read-port-to-string ip)
error[E11]: Generic
  ┌─ :1:2
  │
1 │ (read-port-to-string ip)
  │  ^^^^^^^^^^^^^^^^^^^ read-all-str
```