### PR TITLE
rename `(read-line-from-port)` to `(read-line)`, trim trailing newline

### DIFF
--- a/crates/steel-core/tests/modules/front-matter.scm
+++ b/crates/steel-core/tests/modules/front-matter.scm
@@ -7,9 +7,11 @@
 (struct Page (path front-matter-map content))
 
 (define (parse-file path)
-  (let ([file (open-input-file path)] [front-matter (open-output-string)])
-    (let loop ([port file] [close-front-matter #f])
-      (let ([next-line (read-line-from-port port)])
+  (let ([file (open-input-file path)]
+        [front-matter (open-output-string)])
+    (let loop ([port file]
+               [close-front-matter #f])
+      (let ([next-line (read-line port)])
         (cond
           ;; TODO: Fix 'eof
           [(equal? 'eof next-line)]

--- a/docs/src/builtins/steel_base.md
+++ b/docs/src/builtins/steel_base.md
@@ -1679,6 +1679,15 @@ Creates a mutable vector of a given size, optionally initialized with a specifie
 > (make-vector 3) ;; => '#(0 0 0)
 > (make-vector 3 42) ;; => '#(42 42 42)
 ```
+### **make-weak-box**
+Allocates a weak box.
+
+A weak box is similar to a box, but when the garbage collector can prove
+that the value of a weak box is only reachable through weak references,
+the weak box value will always return #false.
+
+In other words, a weak box does not keep the value contained alive through
+a gc collection.
 ### **mapping**
 Create a mapping iterator
 
@@ -2259,6 +2268,19 @@ Checks whether the given value is a #<ReadDir>
 (read-dir-iter? my-iter) ;; => #true
 (read-dir-iter "not an iter") ;; => #false
 ```
+### **read-line**
+Reads a line from an input port.
+
+(read-line [port]) -> string?
+
+* port : input-port? = (current-input-port)
+### **read-line-from-port**
+Reads a line from the given port, including the '\n' at the end.
+
+Use of this procedure is discouraged in favor of the (read-line) procedure,
+which is included in the scheme spec and therefore more portable.
+
+(read-line-from-port port?) -> string?
 ### **read-port-to-string**
 Takes a port and reads the entire content into a string
 
@@ -3106,6 +3128,21 @@ Sets the value at a specified index in a mutable vector.
 > (vector-set! A 1 42) ;;
 > A ;; => '#(1 42 3)
 ```
+### **vector-swap!**
+Swaps the value at a specified indices in a mutable vector.
+
+(vector-set! vec index value) -> void?
+
+* vec : vector? - The mutable vector to modify.
+* index : integer? - The position in `vec` to update (must be within bounds).
+* value : any? - The new value to store at `index`.
+
+#### Examples
+```scheme
+> (define A (mutable-vector 1 2 3)) ;;
+> (vector-set! A 1 42) ;;
+> A ;; => '#(1 42 3)
+```
 ### **vector?**
 Returns true if the value is a vector (mutable or immutable).
 
@@ -3137,6 +3174,19 @@ Returns true if the value is `void`.
 
 > (void? 42)
 #false
+```
+### **weak-box-value**
+Returns the value contained in the weak box.
+If the garbage collector has proven that the previous content
+value of weak-box was reachable only through a weak reference,
+then default-value (which defaults to #f) is returned.
+
+```scheme
+(define value (make-weak-box 10))
+(weak-box-value value) ;; => 10
+(set! value #f) ;; Wipe out the previous value
+(#%gc-collect)
+(weak-box-value value) ;; => #false
 ```
 ### **would-block-object?**
 Returns `#t` if the value is an EOF object.
@@ -3214,6 +3264,7 @@ Create a zipping iterator
 ### **call-with-current-continuation**
 ### **call-with-exception-handler**
 ### **call/cc**
+### **callstack-hydrate-names**
 ### **cdr-null?**
 ### **channel->recv**
 ### **channel->send**
@@ -3233,6 +3284,7 @@ Create a zipping iterator
 ### **current-function-span**
 ### **current-os!**
 ### **current-thread-id**
+### **dump-profiler**
 ### **duration->micros**
 ### **duration->millis**
 ### **duration->nanos**
@@ -3284,13 +3336,18 @@ Create a zipping iterator
 ### **kill**
 ### **list->vector**
 ### **list-chunks**
+### **list-contains**
 ### **load**
 ### **load-expanded**
 ### **local-executor/block-on**
+### **make-callstack-profiler**
 ### **make-channels**
 ### **make-struct-type**
+### **make-will-executor**
 ### **maybe-get-env-var**
+### **member**
 ### **memory-address**
+### **memq**
 ### **multi-arity?**
 ### **mutable-vector?**
 ### **naive-current-date-local**
@@ -3317,7 +3374,6 @@ Create a zipping iterator
 ### **raise-error**
 ### **raise-error-with-span**
 ### **read!**
-### **read-line-from-port**
 ### **read-to-string**
 ### **run!**
 ### **set-box!**
@@ -3351,6 +3407,7 @@ Create a zipping iterator
 ### **thread/available-parallelism**
 ### **thread::current/id**
 ### **transduce**
+### **truncate**
 ### **try-list-ref**
 ### **unbox**
 ### **unbox-strong**
@@ -3360,5 +3417,7 @@ Create a zipping iterator
 ### **wait**
 ### **wait->stdout**
 ### **which**
+### **will-execute**
+### **will-register**
 ### **would-block**
 ### **write-line!**

--- a/docs/src/builtins/steel_lists.md
+++ b/docs/src/builtins/steel_lists.md
@@ -314,6 +314,9 @@ error[E11]: Generic
 ### **cdr-null?**
 ### **list->vector**
 ### **list-chunks**
+### **list-contains**
+### **member**
+### **memq**
 ### **plist-get**
 ### **plist-get-kwarg**
 ### **plist-get-positional-arg**

--- a/docs/src/builtins/steel_meta.md
+++ b/docs/src/builtins/steel_meta.md
@@ -6,6 +6,28 @@ including the command name as first argument.
 Returns the message of an error object.
 
 (error-object-message error?) -> string?
+### **make-weak-box**
+Allocates a weak box.
+
+A weak box is similar to a box, but when the garbage collector can prove
+that the value of a weak box is only reachable through weak references,
+the weak box value will always return #false.
+
+In other words, a weak box does not keep the value contained alive through
+a gc collection.
+### **weak-box-value**
+Returns the value contained in the weak box.
+If the garbage collector has proven that the previous content
+value of weak-box was reachable only through a weak reference,
+then default-value (which defaults to #f) is returned.
+
+```scheme
+(define value (make-weak-box 10))
+(weak-box-value value) ;; => 10
+(set! value #f) ;; Wipe out the previous value
+(#%gc-collect)
+(weak-box-value value) ;; => #false
+```
 ### **%#interner-memory-usage**
 ### **%iterator?**
 ### **Engine::add-module**
@@ -25,8 +47,10 @@ Returns the message of an error object.
 ### **call-with-current-continuation**
 ### **call-with-exception-handler**
 ### **call/cc**
+### **callstack-hydrate-names**
 ### **current-function-span**
 ### **current-os!**
+### **dump-profiler**
 ### **emit-expanded**
 ### **env-var**
 ### **error-with-span**
@@ -46,7 +70,9 @@ Returns the message of an error object.
 ### **load**
 ### **load-expanded**
 ### **local-executor/block-on**
+### **make-callstack-profiler**
 ### **make-struct-type**
+### **make-will-executor**
 ### **maybe-get-env-var**
 ### **memory-address**
 ### **multi-arity?**
@@ -69,3 +95,5 @@ Returns the message of an error object.
 ### **unbox-strong**
 ### **value->iterator**
 ### **value->string**
+### **will-execute**
+### **will-register**

--- a/docs/src/builtins/steel_numbers.md
+++ b/docs/src/builtins/steel_numbers.md
@@ -600,3 +600,4 @@ Checks if the given real number is zero.
 > (zero? 0.0) ;; => #t
 > (zero? 0.1) ;; => #f
 ```
+### **truncate**

--- a/docs/src/builtins/steel_ports.md
+++ b/docs/src/builtins/steel_ports.md
@@ -143,6 +143,19 @@ Reads the next character from an input port.
 (read-char [port]) -> char?
 
 * port : input-port? = (current-input-port)
+### **read-line**
+Reads a line from an input port.
+
+(read-line [port]) -> string?
+
+* port : input-port? = (current-input-port)
+### **read-line-from-port**
+Reads a line from the given port, including the '\n' at the end.
+
+Use of this procedure is discouraged in favor of the (read-line) procedure,
+which is included in the scheme spec and therefore more portable.
+
+(read-line-from-port port?) -> string?
 ### **read-port-to-string**
 Takes a port and reads the entire content into a string
 
@@ -178,7 +191,6 @@ Writes the contents of a bytevector into an output port.
 * buf : bytes?
 * port : output-port? = (current-output-port)
 ### **flush-output-port**
-### **read-line-from-port**
 ### **stdout**
 ### **would-block**
 ### **write-line!**

--- a/docs/src/builtins/steel_vectors.md
+++ b/docs/src/builtins/steel_vectors.md
@@ -308,4 +308,19 @@ Sets the value at a specified index in a mutable vector.
 > (vector-set! A 1 42) ;;
 > A ;; => '#(1 42 3)
 ```
+### **vector-swap!**
+Swaps the value at a specified indices in a mutable vector.
+
+(vector-set! vec index value) -> void?
+
+* vec : vector? - The mutable vector to modify.
+* index : integer? - The position in `vec` to update (must be within bounds).
+* value : any? - The new value to store at `index`.
+
+#### Examples
+```scheme
+> (define A (mutable-vector 1 2 3)) ;;
+> (vector-set! A 1 42) ;;
+> A ;; => '#(1 42 3)
+```
 ### **vector-push!**

--- a/r7rs-benchmarks/tail.scm
+++ b/r7rs-benchmarks/tail.scm
@@ -1,12 +1,13 @@
 (require "common.scm")
 
-(define read-line read-line-from-port)
 (define file-exists? path-exists?)
 (define delete-file delete-file!)
 
 (define (tail-r-aux port file-so-far)
   (let ([x (read-line port)])
-    (if (eof-object? x) file-so-far (tail-r-aux port (cons x file-so-far)))))
+    (if (eof-object? x)
+        file-so-far
+        (tail-r-aux port (cons x file-so-far)))))
 
 (define (echo-lines-in-reverse-order in out)
   (for-each (lambda (line)

--- a/steel-examples/streams.scm
+++ b/steel-examples/streams.scm
@@ -5,7 +5,9 @@
   (stream-cons n (lambda () (integers (+ 1 n)))))
 
 (define (in-range-stream n m)
-  (if (= n m) empty-stream (stream-cons n (lambda () (in-range-stream (add1 n) m)))))
+  (if (= n m)
+      empty-stream
+      (stream-cons n (lambda () (in-range-stream (add1 n) m)))))
 
 (define (append-streams s1 s2)
   (cond
@@ -14,7 +16,8 @@
     [else (stream-cons (stream-car s1) (lambda () (append-streams (stream-cdr s1) s2)))]))
 
 (define (add-streams s1 s2)
-  (let ([h1 (stream-car s1)] [h2 (stream-car s2)])
+  (let ([h1 (stream-car s1)]
+        [h2 (stream-car s2)])
     (stream-cons (+ h1 h2) (lambda () (add-streams (stream-cdr s1) (stream-cdr s2))))))
 
 (define (merge-streams s1 s2)
@@ -22,7 +25,8 @@
     [(stream-empty? s1) s2] ; nothing to merge from s1
     [(stream-empty? s2) s1] ; nothing to merge from s2
     [else
-     (let ([h1 (stream-car s1)] [h2 (stream-car s2)])
+     (let ([h1 (stream-car s1)]
+           [h2 (stream-car s2)])
        (stream-cons
         h1
         (lambda () (stream-cons h2 (lambda () (merge-streams (stream-cdr s1) (stream-cdr s2)))))))]))
@@ -33,11 +37,15 @@
     [else (stream-cons (func (stream-car s)) (lambda () (map-stream func (stream-cdr s))))]))
 
 (define (list->stream lst)
-  (if (null? lst) empty-stream (stream-cons (car lst) (lambda () (list->stream (cdr lst))))))
+  (if (null? lst)
+      empty-stream
+      (stream-cons (car lst) (lambda () (list->stream (cdr lst))))))
 
 (define (stream->list s)
   (define (*stream->list s lst)
-    (if (stream-empty? s) lst (*stream->list (stream-cdr s) (cons (stream-car s) lst))))
+    (if (stream-empty? s)
+        lst
+        (*stream->list (stream-cdr s) (cons (stream-car s) lst))))
   (*stream->list s '()))
 
 (define (stream-section n stream)
@@ -65,8 +73,10 @@
 (define my-port (open-input-file "scheme_examples/dfs.rkt"))
 
 (define (port-stream)
-  (let ([head (read-line-from-port my-port)])
-    (if (equal? 'eof head) empty-stream (stream-cons head (lambda () (port-stream))))))
+  (let ([head (read-line my-port)])
+    (if (equal? 'eof head)
+        empty-stream
+        (stream-cons head (lambda () (port-stream))))))
 
 ;; Make a stream out of a port
 ;; Access the port using the given func
@@ -77,4 +87,4 @@
         empty-stream
         (stream-cons head (lambda () (port->stream p func end-sym))))))
 
-(transduce (port-stream my-port read-line-from-port 'eof) (taking 15) (into-list))
+(transduce (port-stream my-port read-line 'eof) (taking 15) (into-list))


### PR DESCRIPTION
this makes it imo more in-line with the other port reading functions,
`read` is not named `read-from-port` for example, and it matches the name
of the equivalent r7rs procedure.

in addition, the r7rs spec says, that the return value is "a string containing all of
the text up to *(but not including)* the end of line".

the reason for the size of this pr is, that it changes the output of `tail.scm`, since that reads from a file via `read-line`, which results in half the newlines, which results in half the lines, which is a -30k diff ...

additionally it has apparently been a while since someone ran `cargo xtask docgen`, which is why there is a pretty large diff there as well. the actual change is less than 100 lines diff.