### PR TITLE
 vector-set!/swap!: fix docs and crash

### DIFF
--- a/crates/steel-core/src/primitives/vectors.rs
+++ b/crates/steel-core/src/primitives/vectors.rs
@@ -954,19 +954,19 @@ pub fn mut_vec_set(vec: &HeapRef<Vec<SteelVal>>, i: usize, value: SteelVal) -> R
     Ok(SteelVal::Void)
 }
 
-/// Swaps the value at a specified indices in a mutable vector.
+/// Swaps the value of the specified indices in a mutable vector.
 ///
-/// (vector-set! vec index value) -> void?
+/// (vector-swap! vec a b) -> void?
 ///
 /// * vec : vector? - The mutable vector to modify.
-/// * index : integer? - The position in `vec` to update (must be within bounds).
-/// * value : any? - The new value to store at `index`.
+/// * a : integer? - The first index of `vec` to swap with `b` (must be within bounds).
+/// * b : integer? - The first index of `vec` to swap with `a` (must be within bounds).
 ///
 /// # Examples
 /// ```scheme
 /// > (define A (mutable-vector 1 2 3)) ;;
-/// > (vector-set! A 1 42) ;;
-/// > A ;; => '#(1 42 3)
+/// > (vector-swap! A 0 1) ;;
+/// > A ;; => '#(2 1 3)
 /// ```
 #[steel_derive::function(name = "vector-swap!")]
 pub fn mut_vec_swap(vec: &HeapRef<Vec<SteelVal>>, i: usize, j: usize) -> Result<SteelVal> {

--- a/crates/steel-core/src/primitives/vectors.rs
+++ b/crates/steel-core/src/primitives/vectors.rs
@@ -944,7 +944,7 @@ pub fn mut_vec_set(vec: &HeapRef<Vec<SteelVal>>, i: usize, value: SteelVal) -> R
 
     let guard = &mut ptr.write().value;
 
-    if i as usize > guard.len() {
+    if i >= guard.len() {
         stop!(Generic => "index out of bounds, index given: {:?}, length of vector: {:?}", i, guard.len());
     }
 
@@ -974,8 +974,10 @@ pub fn mut_vec_swap(vec: &HeapRef<Vec<SteelVal>>, i: usize, j: usize) -> Result<
 
     let guard = &mut ptr.write().value;
 
-    if i as usize > guard.len() {
+    if i >= guard.len() {
         stop!(Generic => "index out of bounds, index given: {:?}, length of vector: {:?}", i, guard.len());
+    } else if j >= guard.len() {
+        stop!(Generic => "index out of bounds, index given: {:?}, length of vector: {:?}", j, guard.len());
     }
 
     guard.swap(i, j);

--- a/docs/src/builtins/steel_base.md
+++ b/docs/src/builtins/steel_base.md
@@ -3129,19 +3129,19 @@ Sets the value at a specified index in a mutable vector.
 > A ;; => '#(1 42 3)
 ```
 ### **vector-swap!**
-Swaps the value at a specified indices in a mutable vector.
+Swaps the value of the specified indices in a mutable vector.
 
-(vector-set! vec index value) -> void?
+(vector-swap! vec a b) -> void?
 
 * vec : vector? - The mutable vector to modify.
-* index : integer? - The position in `vec` to update (must be within bounds).
-* value : any? - The new value to store at `index`.
+* a : integer? - The first index of `vec` to swap with `b` (must be within bounds).
+* b : integer? - The first index of `vec` to swap with `a` (must be within bounds).
 
 #### Examples
 ```scheme
 > (define A (mutable-vector 1 2 3)) ;;
-> (vector-set! A 1 42) ;;
-> A ;; => '#(1 42 3)
+> (vector-swap! A 0 1) ;;
+> A ;; => '#(2 1 3)
 ```
 ### **vector?**
 Returns true if the value is a vector (mutable or immutable).

--- a/docs/src/builtins/steel_vectors.md
+++ b/docs/src/builtins/steel_vectors.md
@@ -309,18 +309,18 @@ Sets the value at a specified index in a mutable vector.
 > A ;; => '#(1 42 3)
 ```
 ### **vector-swap!**
-Swaps the value at a specified indices in a mutable vector.
+Swaps the value of the specified indices in a mutable vector.
 
-(vector-set! vec index value) -> void?
+(vector-swap! vec a b) -> void?
 
 * vec : vector? - The mutable vector to modify.
-* index : integer? - The position in `vec` to update (must be within bounds).
-* value : any? - The new value to store at `index`.
+* a : integer? - The first index of `vec` to swap with `b` (must be within bounds).
+* b : integer? - The first index of `vec` to swap with `a` (must be within bounds).
 
 #### Examples
 ```scheme
 > (define A (mutable-vector 1 2 3)) ;;
-> (vector-set! A 1 42) ;;
-> A ;; => '#(1 42 3)
+> (vector-swap! A 0 1) ;;
+> A ;; => '#(2 1 3)
 ```
 ### **vector-push!**


### PR DESCRIPTION
the previous docs for vector-swap! were essentially just copied from vector-set!, so they weren't very helpful.

additionally, it was previously relatively easy to accidentally crash steel due to using a > instead of the more appropriate >= in a bounds check. in addition, the bounds check for the second index in vector-swap! was forgotten.

```
$ steel
λ > (define v (mutable-vector 1 2 3))
λ > (vector-set! v 3 4)
thread 'main' panicked at crates/steel-core/src/primitives/vectors.rs:950:10:
index out of bounds: the len is 3 but the index is 3
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```