### PR TITLE
better messages for tokenizer errors

### DIFF
--- a/crates/steel-repl/src/highlight.rs
+++ b/crates/steel-repl/src/highlight.rs
@@ -129,7 +129,9 @@ impl Validator for RustylineHelper {
                 Err(err) => {
                     unfinished = std::matches!(
                         err.ty,
-                        TokenError::IncompleteString | TokenError::IncompleteIdentifier
+                        TokenError::IncompleteString
+                            | TokenError::IncompleteIdentifier
+                            | TokenError::IncompleteComment
                     );
 
                     break;


### PR DESCRIPTION
This adds more detail to our tokenizer errors. In particular, it sets correct errors spans so the error is pinpointed instead of reporting the whole token.


## Demo
```
error[E09]: Parse
  ┌─ ./steel/foo.scm:3:14
  │
3 │ "adsfadsf\   a
  │              ^ Parse: Syntax Error: unexpected character, expected whitespace or newline

error[E09]: Parse
  ┌─ ./steel/foo.scm:3:10
  │
3 │ "adsfadsf\zxx"
  │          ^^ Parse: Syntax Error: invalid escape 'z'

error[E09]: Parse
  ┌─ ./steel/foo.scm:3:5
  │
3 │ #(x #\hello z)
  │     ^^^^^^^ Parse: Syntax Error: invalid character name

error[E09]: Parse
  ┌─ ./steel/foo.scm:3:10
  │
3 │ #(x "asdf\xdeadbeef" z)
  │          ^^^^^^^^^^ Parse: Syntax Error: unclosed hex escape, expected ';'

error[E09]: Parse
  ┌─ ./steel/foo.scm:3:5
  │
3 │ #(x #\u{dead z)
  │     ^^^^^^^^ Parse: Syntax Error: unclosed hex escape, expected '}'

error[E09]: Parse
  ┌─ ./steel/foo.scm:3:5
  │
3 │ #(x #\xafz z)
  │     ^^^^^^ Parse: Syntax Error: invalid hex escape literal, invalid digit found in string

error[E09]: Parse
  ┌─ ./steel/foo.scm:3:9
  │
3 │ #(x "foo\u{d803}adsfa" z)
  │         ^^^^^^^^ Parse: Syntax Error: invalid code point d803

error[E09]: Parse
  ┌─ ./steel/foo.scm:3:9
  │
3 │ #(x "foo\u{deadbeefdeadbeef}adsfa" z)
  │         ^^^^^^^^^^^^^^^^^^^^ Parse: Syntax Error: invalid hex escape literal, number too large to fit in target type

```