### PR TITLE
improve port `write`

### DIFF
--- a/crates/steel-core/src/values/port.rs
+++ b/crates/steel-core/src/values/port.rs
@@ -382,10 +382,8 @@ impl SteelPortRepr {
 
     pub fn write_char(&mut self, c: char) -> Result<()> {
         let mut buf = [0; 4];
-
         let s = c.encode_utf8(&mut buf);
-
-        let _ = self.write_without_flush(s.as_bytes())?;
+        let _ = self.write(s.as_bytes())?;
 
         Ok(())
     }
@@ -461,38 +459,6 @@ impl SteelPortRepr {
     }
 
     pub fn write(&mut self, buf: &[u8]) -> Result<usize> {
-        macro_rules! write_and_flush(
-            ($br: expr) => {{
-                let result = $br.write(buf)?;
-                $br.flush()?;
-                result
-            }};
-        );
-
-        let result = match self {
-            SteelPortRepr::FileOutput(_, writer) => write_and_flush![writer],
-            SteelPortRepr::StdOutput(writer) => write_and_flush![writer],
-            SteelPortRepr::StdError(writer) => write_and_flush![writer],
-            SteelPortRepr::ChildStdInput(writer) => write_and_flush![writer],
-            SteelPortRepr::StringOutput(writer) => write_and_flush![writer],
-            SteelPortRepr::DynWriter(writer) => write_and_flush![writer.lock().unwrap()],
-            // TODO: Should tcp streams be both input and output ports?
-            SteelPortRepr::TcpStream(tcp) => tcp.write(buf)?,
-            SteelPortRepr::FileInput(_, _)
-            | SteelPortRepr::StdInput(_)
-            | SteelPortRepr::DynReader(_)
-            | SteelPortRepr::ChildStdOutput(_)
-            | SteelPortRepr::ChildStdError(_)
-            | SteelPortRepr::StringInput(_) => {
-                stop!(ContractViolation => "expected output-port?, found {}", self)
-            }
-            SteelPortRepr::Closed => stop!(Io => "port is closed"),
-        };
-
-        Ok(result)
-    }
-
-    pub fn write_without_flush(&mut self, buf: &[u8]) -> Result<usize> {
         macro_rules! write_and_flush(
             ($br: expr) => {{
                 let result = $br.write(buf)?;

--- a/crates/steel-core/src/values/port.rs
+++ b/crates/steel-core/src/values/port.rs
@@ -459,20 +459,13 @@ impl SteelPortRepr {
     }
 
     pub fn write(&mut self, buf: &[u8]) -> Result<usize> {
-        macro_rules! write_and_flush(
-            ($br: expr) => {{
-                let result = $br.write(buf)?;
-                result
-            }};
-        );
-
         let result = match self {
-            SteelPortRepr::FileOutput(_, writer) => write_and_flush![writer],
-            SteelPortRepr::StdOutput(writer) => write_and_flush![writer],
-            SteelPortRepr::StdError(writer) => write_and_flush![writer],
-            SteelPortRepr::ChildStdInput(writer) => write_and_flush![writer],
-            SteelPortRepr::StringOutput(writer) => write_and_flush![writer],
-            SteelPortRepr::DynWriter(writer) => write_and_flush![writer.lock().unwrap()],
+            SteelPortRepr::FileOutput(_, writer) => writer.write(buf)?,
+            SteelPortRepr::StdOutput(writer) => writer.write(buf)?,
+            SteelPortRepr::StdError(writer) => writer.write(buf)?,
+            SteelPortRepr::ChildStdInput(writer) => writer.write(buf)?,
+            SteelPortRepr::StringOutput(writer) => writer.write(buf)?,
+            SteelPortRepr::DynWriter(writer) => writer.lock().unwrap().write(buf)?,
             // TODO: Should tcp streams be both input and output ports?
             SteelPortRepr::TcpStream(tcp) => tcp.write(buf)?,
             SteelPortRepr::FileInput(_, _)


### PR DESCRIPTION
previously in all calls to `write` (except when writing a single char), the buffer would be flushed. this essentially eliminates any performance benefit of even using a BufWriter, as now `write-string`, `write-byte`, `#%raw-display` etc are not actually buffered writes. additionally r7rs includes a procedure to explicitly flush the output port, so i don't think it should be flushed implicitly (and guile for example doesn't either). now it doesn't flush implicitly either.

doing this then vastly simplifies the write part of the ports file, as i can now remove the `write_without_flush` function, as the write function no longer flushes, and can remove the `write_and_flush!` macro.

additionally switch from using `write` to `write_all`. the [`write` docs](https://doc.rust-lang.org/beta/std/io/trait.Write.html#tymethod.write) mention that an error of kind `Interrupted` is not fatal and the write op should be retried, which is exactly what [`write_all` does](https://doc.rust-lang.org/beta/std/io/trait.Write.html#method.write_all), so just use that one.