### PR TITLE
Fix issue #503: Refactor wasm32 cfg to family/env checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3799,7 +3799,7 @@ dependencies = [
  "triomphe",
  "ureq 3.1.0",
  "weak-table",
- "which 7.0.3",
+ "which 8.0.0",
  "xdg",
 ]
 
@@ -4872,6 +4872,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
 dependencies = [
  "either",
+ "env_home",
+ "rustix 1.0.8",
+ "winsafe",
+]
+
+[[package]]
+name = "which"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fabb953106c3c8eea8306e4393700d7657561cb43122571b172bbfb7c7ba1d"
+dependencies = [
  "env_home",
  "rustix 1.0.8",
  "winsafe",

--- a/crates/steel-core/Cargo.toml
+++ b/crates/steel-core/Cargo.toml
@@ -105,12 +105,14 @@ shared_vector = "0.4.4"
 
 imbl = { version = "6", optional = true, features = ["triomphe", "serde"] }
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
+[target.'cfg(target_family = "wasm")'.dependencies]
 getrandom = { version = "0.3.1", features = ["wasm_js"] }
 
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-which = "7.0.0"
-polling = "3.7.3"
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+polling = "3.10.0"
+
+[target.'cfg(not(any(target_family = "wasm", target_env = "newlib")))'.dependencies]
+which = "8.0.0"
 
 [dev-dependencies]
 proptest = "1.1.0"

--- a/crates/steel-core/src/compiler/modules.rs
+++ b/crates/steel-core/src/compiler/modules.rs
@@ -130,7 +130,7 @@ create_prelude!(
     for_syntax "#%private/steel/contract"
 );
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_family = "wasm"))]
 pub static STEEL_SEARCH_PATHS: Lazy<Option<Vec<PathBuf>>> = Lazy::new(|| {
     std::env::var("STEEL_SEARCH_PATHS").ok().map(|x| {
         std::env::split_paths(x.as_str())
@@ -140,14 +140,14 @@ pub static STEEL_SEARCH_PATHS: Lazy<Option<Vec<PathBuf>>> = Lazy::new(|| {
 });
 
 pub fn steel_search_dirs() -> Vec<PathBuf> {
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(not(target_family = "wasm"))]
     return STEEL_SEARCH_PATHS.clone().unwrap_or_default();
 
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(target_family = "wasm")]
     return Vec::new();
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_family = "wasm"))]
 pub static STEEL_HOME: Lazy<Option<String>> = Lazy::new(|| {
     std::env::var("STEEL_HOME").ok().or_else(|| {
         let home = env_home::env_home_dir().map(|x| x.join(".steel"));
@@ -194,7 +194,7 @@ pub static STEEL_HOME: Lazy<Option<String>> = Lazy::new(|| {
     })
 });
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 pub static STEEL_HOME: Lazy<Option<String>> = Lazy::new(|| None);
 
 pub fn steel_home() -> Option<String> {
@@ -1896,14 +1896,14 @@ impl<'a> ModuleBuilder<'a> {
         // change the path to not always be required
         // if its not required we know its not coming in
 
-        #[cfg(not(target_arch = "wasm32"))]
+        #[cfg(not(target_family = "wasm"))]
         let name = if let Some(p) = name {
             std::fs::canonicalize(p)?
         } else {
             std::env::current_dir()?
         };
 
-        #[cfg(target_arch = "wasm32")]
+        #[cfg(target_family = "wasm")]
         let name = PathBuf::new();
 
         Ok(ModuleBuilder {
@@ -2076,7 +2076,7 @@ impl<'a> ModuleBuilder<'a> {
                 .filter(|x| matches!(x.path, PathOrBuiltIn::Path(_)))
                 .map(|x| (x.path.get_path(), x.span))
             {
-                if cfg!(target_arch = "wasm32") {
+                if cfg!(target_family = "wasm") {
                     stop!(Generic => "requiring modules is not supported for wasm");
                 }
 
@@ -2638,7 +2638,7 @@ impl<'a> ModuleBuilder<'a> {
                     return Ok(());
                 }
 
-                if cfg!(target_arch = "wasm32") {
+                if cfg!(target_family = "wasm") {
                     stop!(Generic => "requiring modules is not supported for wasm");
                 }
 

--- a/crates/steel-core/src/compiler/program.rs
+++ b/crates/steel-core/src/compiler/program.rs
@@ -1352,9 +1352,9 @@ impl RawProgramWithSymbols {
         Ok(Executable {
             name: Shared::new(name),
             version: Shared::new(self.version),
-            #[cfg(not(target_arch = "wasm32"))]
+            #[cfg(not(target_family = "wasm"))]
             time_stamp: Some(SystemTime::now()),
-            #[cfg(target_arch = "wasm32")]
+            #[cfg(target_family = "wasm")]
             time_stamp: None,
             instructions: instructions
                 .into_iter()

--- a/crates/steel-core/src/core/instructions.rs
+++ b/crates/steel-core/src/core/instructions.rs
@@ -143,12 +143,12 @@ impl u24 {
     #[inline(always)]
     pub fn to_usize(self) -> usize {
         let u24([a, b, c]) = self;
-        #[cfg(target_arch = "wasm32")]
+        #[cfg(target_pointer_width = "32")]
         {
             return usize::from_le_bytes([a, b, c, 0]);
         }
 
-        #[cfg(not(target_arch = "wasm32"))]
+        #[cfg(not(target_pointer_width = "32"))]
         usize::from_le_bytes([a, b, c, 0, 0, 0, 0, 0])
     }
 }

--- a/crates/steel-core/src/primitives.rs
+++ b/crates/steel-core/src/primitives.rs
@@ -11,7 +11,7 @@ pub mod meta_ops;
 /// Implements numbers as defined in section 6.2 of the R7RS spec.
 pub mod numbers;
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_family = "wasm"))]
 pub mod polling;
 
 pub mod ports;

--- a/crates/steel-core/src/primitives/process.rs
+++ b/crates/steel-core/src/primitives/process.rs
@@ -38,13 +38,13 @@ struct ChildProcess {
 }
 
 fn binary_exists_on_path(binary: String) -> Option<String> {
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(not(any(target_family = "wasm", target_env = "newlib")))]
     match which::which(binary) {
         Ok(v) => Some(v.into_os_string().into_string().unwrap()),
         Err(_) => None,
     }
 
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(any(target_family = "wasm", target_env = "newlib"))]
     None
 }
 

--- a/crates/steel-core/src/steel_vm/primitives.rs
+++ b/crates/steel-core/src/steel_vm/primitives.rs
@@ -89,10 +89,10 @@ use once_cell::sync::Lazy;
 use std::{borrow::Cow, cmp::Ordering};
 use steel_parser::{ast::ExprKind, interner::interned_current_memory_usage, parser::SourceId};
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_family = "wasm"))]
 use crate::primitives::polling::polling_module;
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 fn polling_module() -> BuiltInModule {
     let mut module = BuiltInModule::new("steel/polling".to_string());
 


### PR DESCRIPTION
This PR refactors the conditional compilation of `target_arch = "wasm32"` to make it more precise:

Replace wasm32 conditional into:

1. Check for 32/64 bit with:
 ```rust
cfg(target_pointer_width = "32")
```
2. Check for wasm with:
```rust
cfg(target_family = "wasm")
```
3. Check for unix/non-unix with: 
```rust
cfg(any(target_family = "wasm", target_env = "newlib"))
```