### PR TITLE
flush stdout in repl after user prompt

### DIFF
--- a/crates/steel-repl/src/repl.rs
+++ b/crates/steel-repl/src/repl.rs
@@ -23,7 +23,7 @@ use steel::{rvals::SteelVal, steel_vm::register_fn::RegisterFn};
 
 use steel::steel_vm::engine::Engine;
 
-use std::io::Read;
+use std::io::{Read, Write};
 
 use std::time::Instant;
 
@@ -95,6 +95,8 @@ fn finish_load_or_interrupt(vm: &mut Engine, exprs: String, path: PathBuf) {
             vm.raise_error(e);
         }
     }
+
+    let _ = std::io::stdout().flush();
 }
 
 fn finish_or_interrupt(vm: &mut Engine, line: String) {
@@ -128,6 +130,8 @@ fn finish_or_interrupt(vm: &mut Engine, line: String) {
             }
         }
     }
+
+    let _ = std::io::stdout().flush();
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
when i changed the buffering in #501 i said that nothing relies on the flushing behaviour of write. turns out, this is incorrect. i still stand by the fact that nothing *should* rely on that behaviour, but the repl actually does.

before:

```
λ > (display 'symbol)
λ > (write "string")
λ > (newline)
symbol"string"
λ > (display (list 1 2 3))
λ >
(1 2 3)CTRL-D
```

after:

```
λ > (display 'symbol)
symbol
λ > (write "string")
"string"
λ > (newline)

λ > (display (list 1 2 3))
(1 2 3)
λ >
CTRL-D
```

this was actually observable before my change as well, when using `(write-char)` in the repl, but it is now significantly more obvious, as it now affects all write calls without a newline.

```
λ > (write-char #\w)
λ > (write-char #\h)
λ > (write-char #\y)
λ > (newline)
why
```