### PR TITLE
expressions always have a span

### DIFF
--- a/crates/steel-core/src/compiler/modules.rs
+++ b/crates/steel-core/src/compiler/modules.rs
@@ -2501,7 +2501,7 @@ impl<'a> ModuleBuilder<'a> {
                     }
                 }
                 _ => {
-                    stop!(TypeMismatch => "provide expects either a (for-syntax <ident>) or an ident"; opt expr.span())
+                    stop!(TypeMismatch => "provide expects either a (for-syntax <ident>) or an ident"; expr.span())
                 }
             }
         }
@@ -2762,7 +2762,7 @@ impl<'a> ModuleBuilder<'a> {
 
                             self.parse_require_object_inner(home, r, &l.args[2], require_object)?;
                         } else {
-                            stop!(TypeMismatch => "prefix-in expects an identifier to use for the prefix"; opt prefix.span());
+                            stop!(TypeMismatch => "prefix-in expects an identifier to use for the prefix"; prefix.span());
                         }
                     }
 
@@ -2833,7 +2833,7 @@ impl<'a> ModuleBuilder<'a> {
                                             }
                                         }
 
-                                        stop!(Generic => format!("Module not found: {:?}", current); mod_name.span().unwrap())
+                                        stop!(Generic => format!("Module not found: {:?}", current); mod_name.span())
                                     }
                                 }
 
@@ -2842,7 +2842,7 @@ impl<'a> ModuleBuilder<'a> {
                                 require_object.path = Some(PathOrBuiltIn::Path(current));
                             }
                         } else {
-                            stop!(BadSyntax => "for-syntax expects a string literal referring to a file or module"; opt mod_name.span());
+                            stop!(BadSyntax => "for-syntax expects a string literal referring to a file or module"; mod_name.span());
                         }
                     }
                     _ => {
@@ -2852,7 +2852,7 @@ impl<'a> ModuleBuilder<'a> {
             }
 
             unknown => {
-                stop!(Generic => format!("require object expected a string literal referring to a file/module, found: {}", unknown); opt atom.span())
+                stop!(Generic => format!("require object expected a string literal referring to a file/module, found: {}", unknown); atom.span())
             }
         }
 

--- a/crates/steel-core/src/parser/expander.rs
+++ b/crates/steel-core/src/parser/expander.rs
@@ -774,7 +774,7 @@ impl MacroPattern {
                 _ => {
                     // TODO: Add pattern matching on other kinds of forms here - probably just a special IR
                     // for the pattern to match against here
-                    stop!(BadSyntax => format!("illegal special form found in macro pattern: {}", expr) ; opt expr.span());
+                    stop!(BadSyntax => format!("illegal special form found in macro pattern: {}", expr) ; expr.span());
                 }
             }
         }

--- a/crates/steel-core/src/rerrs.rs
+++ b/crates/steel-core/src/rerrs.rs
@@ -409,12 +409,6 @@ macro_rules! stop {
     ($type:ident => $thing:expr; $span:expr) => {
         return Err($crate::rerrs::SteelErr::new($crate::rerrs::ErrorKind::$type, ($thing).to_string()).with_span($span))
     };
-    ($type:ident => $thing:expr; opt $span:expr) => {
-        match $span {
-            Some(span) => stop!($type => $thing; span),
-            None => stop!($type => $thing)
-        }
-    };
     ($type:ident => $thing:expr; $span:expr; $source:expr) => {
         return Err($crate::rerrs::SteelErr::new($crate::rerrs::ErrorKind::$type, ($thing).to_string()).with_span($span))
 

--- a/crates/steel-parser/src/ast.rs
+++ b/crates/steel-parser/src/ast.rs
@@ -159,22 +159,22 @@ macro_rules! expr_list {
 }
 
 impl ExprKind {
-    pub fn span(&self) -> Option<Span> {
+    pub fn span(&self) -> Span {
         match self {
-            ExprKind::Atom(expr) => Some(expr.syn.span),
-            ExprKind::If(expr) => Some(expr.location.span),
-            ExprKind::Let(expr) => Some(expr.location.span),
-            ExprKind::Define(expr) => Some(expr.location.span),
-            ExprKind::LambdaFunction(expr) => Some(expr.location.span),
-            ExprKind::Begin(expr) => Some(expr.location.span),
-            ExprKind::Return(expr) => Some(expr.location.span),
-            ExprKind::Quote(expr) => Some(expr.location.span),
-            ExprKind::Macro(expr) => Some(expr.location.span),
-            ExprKind::SyntaxRules(expr) => Some(expr.location.span),
-            ExprKind::List(expr) => Some(expr.location),
-            ExprKind::Set(expr) => Some(expr.location.span),
-            ExprKind::Require(expr) => Some(expr.location.span),
-            ExprKind::Vector(vec) => Some(vec.span),
+            ExprKind::Atom(expr) => expr.syn.span,
+            ExprKind::If(expr) => expr.location.span,
+            ExprKind::Let(expr) => expr.location.span,
+            ExprKind::Define(expr) => expr.location.span,
+            ExprKind::LambdaFunction(expr) => expr.location.span,
+            ExprKind::Begin(expr) => expr.location.span,
+            ExprKind::Return(expr) => expr.location.span,
+            ExprKind::Quote(expr) => expr.location.span,
+            ExprKind::Macro(expr) => expr.location.span,
+            ExprKind::SyntaxRules(expr) => expr.location.span,
+            ExprKind::List(expr) => expr.location,
+            ExprKind::Set(expr) => expr.location.span,
+            ExprKind::Require(expr) => expr.location.span,
+            ExprKind::Vector(vec) => vec.span,
         }
     }
 
@@ -1567,7 +1567,7 @@ impl PatternPair {
         } else {
             return Err(ParseError::SyntaxError(
                 "syntax-rules expects a list for the pattern".to_string(),
-                pattern.span().unwrap_or_default(),
+                pattern.span(),
                 None,
             ));
         }

--- a/crates/steel-parser/src/parser.rs
+++ b/crates/steel-parser/src/parser.rs
@@ -1883,7 +1883,7 @@ impl Frame {
 
                 return Err(ParseError::SyntaxError(
                     "improper list must have a single cdr".to_owned(),
-                    expr.span().unwrap_or_default(),
+                    expr.span(),
                     None,
                 ));
             }
@@ -1898,7 +1898,7 @@ impl Frame {
         if !valid_for_bytes {
             return Err(ParseError::SyntaxError(
                 "bytevector literals can only contain integer literals in the 0-255 range".into(),
-                expr.span().unwrap_or_default(),
+                expr.span(),
                 None,
             ));
         }


### PR DESCRIPTION
We can return `Span` instead of `Option<Span>` now for expressions.