### PR TITLE
steel-lsp: negotiate position encoding and prefer utf-8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3857,6 +3857,7 @@ dependencies = [
 name = "steel-language-server"
 version = "0.7.0"
 dependencies = [
+ "crossbeam-utils",
  "dashmap 5.5.3",
  "env_logger",
  "log",

--- a/crates/steel-language-server/Cargo.toml
+++ b/crates/steel-language-server/Cargo.toml
@@ -13,7 +13,7 @@ env_logger = "0.10.0"
 ropey = "1.5.0"
 serde_json = "1.0.92"
 tokio = { version = "1.29.1", features = ["full"] }
-tower-lsp = { version = "0.20.0", features = ["proposed"] }
+tower-lsp = { version = "0.20.0" }
 serde = { version = "1.0.152", features = ["derive"] }
 dashmap = "5.1.0"
 log = "0.4.17"

--- a/crates/steel-language-server/Cargo.toml
+++ b/crates/steel-language-server/Cargo.toml
@@ -20,3 +20,4 @@ log = "0.4.17"
 steel-core = { path = "../steel-core", version = "0.7.0", features = ["dylibs", "stacker", "sync", "anyhow"] }
 steel-parser = { path = "../steel-parser", version = "0.7.0" }
 once_cell = "1.18.0"
+crossbeam-utils = "0.8.21"

--- a/crates/steel-language-server/src/backend.rs
+++ b/crates/steel-language-server/src/backend.rs
@@ -90,7 +90,6 @@ impl LanguageServer for Backend {
     async fn initialize(&self, _: InitializeParams) -> Result<InitializeResult> {
         Ok(InitializeResult {
             server_info: None,
-            offset_encoding: None,
             capabilities: ServerCapabilities {
                 inlay_hint_provider: Some(OneOf::Left(true)),
                 text_document_sync: Some(TextDocumentSyncCapability::Kind(

--- a/crates/steel-language-server/src/main.rs
+++ b/crates/steel-language-server/src/main.rs
@@ -7,7 +7,7 @@ use steel::{
     parser::interner::InternedString,
     steel_vm::{engine::Engine, register_fn::RegisterFn},
 };
-use steel_language_server::backend::{lsp_home, Backend, ExternalModuleResolver, ENGINE};
+use steel_language_server::backend::{lsp_home, Backend, Config, ExternalModuleResolver, ENGINE};
 
 use tower_lsp::{LspService, Server};
 
@@ -73,6 +73,7 @@ async fn main() {
     }
 
     let (service, socket) = LspService::build(|client| Backend {
+        config: Config::new(),
         client,
         ast_map: DashMap::new(),
         lowered_ast_map: DashMap::new(),


### PR DESCRIPTION
the most noticeable change is in [69d12564dd2c01ff5e0a23081af9bc2d31010603], where i move the `position_to_offset` and `offset_to_position` to a new `Config` struct, which (in the commit after) then holds the negotiated position encoding. additionally this adds a `span_to_range` function there to move range creation to one place and avoid having to add more parameters to the `create_diagnostic` function.