### PR TITLE
fix `(string-length)` to return chars instead of utf-8 bytes

### DIFF
--- a/crates/steel-core/src/primitives/strings.rs
+++ b/crates/steel-core/src/primitives/strings.rs
@@ -762,7 +762,7 @@ pub fn ends_with(value: &SteelString, suffix: &SteelString) -> bool {
     value.ends_with(suffix.as_str())
 }
 
-/// Get the length of the given string in UTF-8 bytes.
+/// Get the number of characters in the string.
 ///
 /// (string-length string?) -> int?
 ///
@@ -770,12 +770,12 @@ pub fn ends_with(value: &SteelString, suffix: &SteelString) -> bool {
 ///
 /// ```scheme
 /// > (string-length "apples") ;; => 6
-/// > (string-length "✅") ;; => 3
-/// > (string-length "🤖") ;; => 4
+/// > (string-length "αβγ") ;; => 3
+/// > (string-length "✅") ;; => 1
 /// ```
 #[function(name = "string-length")]
 pub fn string_length(value: &SteelString) -> usize {
-    value.len()
+    value.chars().count()
 }
 
 /// Concatenates all of the given strings into one

--- a/crates/steel-core/src/primitives/strings.rs
+++ b/crates/steel-core/src/primitives/strings.rs
@@ -22,6 +22,7 @@ pub fn string_module() -> BuiltInModule {
         .register_native_fn_definition(STRING_TO_UPPER_DEFINITION)
         .register_native_fn_definition(STRING_TO_LOWER_DEFINITION)
         .register_native_fn_definition(STRING_LENGTH_DEFINITION)
+        .register_native_fn_definition(UTF8_LENGTH_DEFINITION)
         .register_native_fn_definition(TRIM_DEFINITION)
         .register_native_fn_definition(TRIM_START_DEFINITION)
         .register_native_fn_definition(TRIM_END_DEFINITION)
@@ -776,6 +777,22 @@ pub fn ends_with(value: &SteelString, suffix: &SteelString) -> bool {
 #[function(name = "string-length")]
 pub fn string_length(value: &SteelString) -> usize {
     value.chars().count()
+}
+
+/// Get the length of the string in UTF-8 bytes.
+///
+/// (utf8-length string?) -> int?
+///
+/// # Examples
+///
+/// ```scheme
+/// > (utf8-length "apples") ;; => 6
+/// > (utf8-length "αβγ") ;; => 6
+/// > (utf8-length "✅") ;; => 3
+/// ```
+#[function(name = "utf8-length")]
+pub fn utf8_length(value: &SteelString) -> usize {
+    value.len()
 }
 
 /// Concatenates all of the given strings into one

--- a/crates/steel-core/src/tests/mod.rs
+++ b/crates/steel-core/src/tests/mod.rs
@@ -138,7 +138,7 @@ test_harness_success! {
     stack_state,
     stack_struct,
     stack_test_with_contract,
-    string_append,
+    string,
     structs,
     symbols,
     // TODO: @Matt 11/11/2023

--- a/crates/steel-core/src/tests/success/string.scm
+++ b/crates/steel-core/src/tests/success/string.scm
@@ -1,0 +1,7 @@
+(define (assert-equal! expected actual)
+  (unless (equal? expected actual)
+    (error "expected" expected "but got" actual)))
+
+(assert-equal! (string-append) "")
+(assert-equal! (string-append "foo") "foo")
+(assert-equal! (string-append "foo" "bar") "foobar")

--- a/crates/steel-core/src/tests/success/string.scm
+++ b/crates/steel-core/src/tests/success/string.scm
@@ -5,3 +5,18 @@
 (assert-equal! (string-append) "")
 (assert-equal! (string-append "foo") "foo")
 (assert-equal! (string-append "foo" "bar") "foobar")
+
+;; string-length should count chars
+(assert-equal! (string-length "one two") 7)
+(assert-equal! (string-length "αβγ") 3)
+(assert-equal! (string-length "aλ") 2)
+(assert-equal! (string-length "✅") 1)
+(assert-equal! (string-length "") 0)
+
+;; string->bytes should return utf-8 encoding, so it's length should
+;; be the length in utf-8 encoded bytes
+(assert-equal! (bytes-length (string->bytes "one two")) 7)
+(assert-equal! (bytes-length (string->bytes "αβγ")) 6)
+(assert-equal! (bytes-length (string->bytes "aλ")) 3)
+(assert-equal! (bytes-length (string->bytes "✅")) 3)
+(assert-equal! (bytes-length (string->bytes "")) 0)

--- a/crates/steel-core/src/tests/success/string.scm
+++ b/crates/steel-core/src/tests/success/string.scm
@@ -20,3 +20,10 @@
 (assert-equal! (bytes-length (string->bytes "aλ")) 3)
 (assert-equal! (bytes-length (string->bytes "✅")) 3)
 (assert-equal! (bytes-length (string->bytes "")) 0)
+
+;; utf8-length
+(assert-equal! (utf8-length "one two") 7)
+(assert-equal! (utf8-length "αβγ") 6)
+(assert-equal! (utf8-length "aλ") 3)
+(assert-equal! (utf8-length "✅") 3)
+(assert-equal! (utf8-length "") 0)

--- a/crates/steel-core/src/tests/success/string_append.scm
+++ b/crates/steel-core/src/tests/success/string_append.scm
@@ -1,3 +1,0 @@
-(assert! (equal? (string-append) ""))
-(assert! (equal? (string-append "foo") "foo"))
-(assert! (equal? (string-append "foo" "bar") "foobar"))

--- a/docs/src/builtins/steel_base.md
+++ b/docs/src/builtins/steel_base.md
@@ -2697,7 +2697,7 @@ Joins the given list of strings, with an optional separator.
 (string-join '("one" "two" "three") ", ") ;; => "one, two, three"
 ```
 ### **string-length**
-Get the length of the given string in UTF-8 bytes.
+Get the number of characters in the string.
 
 (string-length string?) -> int?
 
@@ -2705,8 +2705,8 @@ Get the length of the given string in UTF-8 bytes.
 
 ```scheme
 > (string-length "apples") ;; => 6
-> (string-length "✅") ;; => 3
-> (string-length "🤖") ;; => 4
+> (string-length "αβγ") ;; => 3
+> (string-length "✅") ;; => 1
 ```
 ### **string-ref**
 Extracts the nth character out of a given string.

--- a/docs/src/builtins/steel_strings.md
+++ b/docs/src/builtins/steel_strings.md
@@ -294,7 +294,7 @@ Joins the given list of strings, with an optional separator.
 (string-join '("one" "two" "three") ", ") ;; => "one, two, three"
 ```
 ### **string-length**
-Get the length of the given string in UTF-8 bytes.
+Get the number of characters in the string.
 
 (string-length string?) -> int?
 
@@ -302,8 +302,8 @@ Get the length of the given string in UTF-8 bytes.
 
 ```scheme
 > (string-length "apples") ;; => 6
-> (string-length "✅") ;; => 3
-> (string-length "🤖") ;; => 4
+> (string-length "αβγ") ;; => 3
+> (string-length "✅") ;; => 1
 ```
 ### **string-ref**
 Extracts the nth character out of a given string.


### PR DESCRIPTION
the scheme spec states, that `(string-length)` "[r]eturns the number of characters", while steel would previously return the number of utf8 bytes.