### PR TITLE
only trim a single space per line for doc comments

### DIFF
--- a/crates/steel-core/src/primitives/lists.rs
+++ b/crates/steel-core/src/primitives/lists.rs
@@ -150,12 +150,11 @@ pub fn chunks(list: &List<SteelVal>) -> Result<SteelVal> {
 ///
 /// ```scheme
 /// > (second '(1 2 3)) ;; => 2
-/// > (second '())
 /// error[E11]: Generic
-///         ┌─ :1:2
-///         │
-///         1 │ (second '())
-///         │  ^^^^^^ second: index out of bounds - list did not have an element in the second position: []
+///   ┌─ :1:2
+///   │
+/// 1 │ (second '())
+///   │  ^^^^^^ second: index out of bounds - list did not have an element in the second position: []
 /// ```
 #[steel_derive::function(name = "second", constant = true)]
 pub fn second(list: &List<SteelVal>) -> Result<SteelVal> {
@@ -173,10 +172,10 @@ pub fn second(list: &List<SteelVal>) -> Result<SteelVal> {
 /// > (third '(1 2 3)) ;; => 3
 /// > (third '())
 /// error[E11]: Generic
-///        ┌─ :1:2
-///        │
-///        1 │ (third '())
-///        │  ^^^^^^ third: index out of bounds - list did not have an element in the second position: []
+///   ┌─ :1:2
+///   │
+/// 1 │ (third '())
+///   │  ^^^^^ third: Index out of bounds - list did not have an element in the second position: []
 /// ```
 #[steel_derive::function(name = "third", constant = true)]
 pub(crate) fn third(list: &List<SteelVal>) -> Result<SteelVal> {
@@ -351,7 +350,7 @@ macro_rules! debug_unreachable {
 
 /// Returns a newly allocated list of the elements in the range [n, m) or [0, m) when n is not given.
 ///
-/// (range m)   -> (listof int?)
+/// (range m)   -> (listof int?)  
 /// (range n m) -> (listof int?)
 ///
 /// * n : int?
@@ -505,10 +504,10 @@ fn cdr_is_null(args: &[SteelVal]) -> Result<SteelVal> {
 /// > (cdr (list 10)) ;; => '()
 /// > (cdr '())
 /// error[E11]: Generic
-///    ┌─ :1:2
-///    │
-///    1 │ (cdr '())
-///    │  ^^^ cdr expects a non empty list
+///   ┌─ :1:2
+///   │
+/// 1 │ (cdr '())
+///   │  ^^^ cdr expects a non empty list
 /// ```
 #[steel_derive::function(name = "cdr", constant = true)]
 pub(crate) fn cdr(arg: &mut SteelVal) -> Result<SteelVal> {
@@ -541,12 +540,12 @@ pub(crate) fn cdr(arg: &mut SteelVal) -> Result<SteelVal> {
 /// ```scheme
 /// > (rest (list 10 20 30)) ;; => '(20 30)
 /// > (rest (list 10)) ;; => '()
-/// > (rest '() )
+/// > (rest '())
 /// error[E11]: Generic
-///    ┌─ :1:2
-///    │
-///    1 │ (rest '())
-///    │  ^^^^ rest expects a non empty list
+///   ┌─ :1:2
+///   │
+/// 1 │ (rest '())
+///   │  ^^^^ rest expects a non empty list
 /// ```
 #[steel_derive::function(name = "rest", constant = true, arity = "Exact(1)")]
 fn rest(arg: &mut SteelVal) -> Result<SteelVal> {

--- a/crates/steel-derive/src/lib.rs
+++ b/crates/steel-derive/src/lib.rs
@@ -637,7 +637,11 @@ fn parse_doc_comment(input: ItemFn) -> Option<proc_macro2::TokenStream> {
                     .map(|s| s.to_string())
                     .collect::<Vec<_>>()
             })
-            .map(|line| line.trim().to_string())
+            .map(|line| {
+                line.strip_prefix(" ")
+                    .map(ToOwned::to_owned)
+                    .unwrap_or(line)
+            })
             .collect();
 
         let doc = trimmed.join("\n");

--- a/docs/src/builtins/steel_base.md
+++ b/docs/src/builtins/steel_base.md
@@ -422,10 +422,10 @@ Returns the rest of the list. Will raise an error if the list is empty.
 > (cdr (list 10)) ;; => '()
 > (cdr '())
 error[E11]: Generic
-┌─ :1:2
-│
+  ┌─ :1:2
+  │
 1 │ (cdr '())
-│  ^^^ cdr expects a non empty list
+  │  ^^^ cdr expects a non empty list
 ```
 ### **ceiling**
 Rounds the given number up to the nearest integer not less than it.
@@ -674,9 +674,9 @@ Compose multiple iterators into one iterator
 #### Examples
 ```scheme
 (compose
-(mapping (λ (x) (+ x 1)))
-(filtering odd?)
-(taking 15))
+    (mapping (λ (x) (+ x 1)))
+    (filtering odd?)
+    (taking 15))
 ```
 ### **concat-symbols**
 Concatenates zero or more symbols into a new symbol.
@@ -1658,10 +1658,10 @@ time complexity is O(n/64). Meaning, for small lists this can be constant.
 > (list-ref (range 0 100) 42) ;; => 42"
 > (list-ref (list 1 2 3 4) 10)
 error[E11]: Generic
-┌─ :1:2
-│
+  ┌─ :1:2
+  │
 1 │ (list-ref (list 1 2 3 4) 10)
-│  ^^^^^^^^ out of bounds index in list-ref - list length: 4, index: 10
+  │  ^^^^^^^^ out of bounds index in list-ref - list length: 4, index: 10
 ```
 ### **list-tail**
 Same as `list-drop`, except raise an error if `n` is greater than the length of `lst`.
@@ -1676,11 +1676,11 @@ Same as `list-drop`, except raise an error if `n` is greater than the length of 
 > (list-tail '(1 2 3 4 5) 2) ;; => '(3 4 5)
 > (list-tail '() 3)
 error[E11]: Generic
-┌─ :1:2
-│
+  ┌─ :1:2
+  │
 1 │ (list-tail '() 3)
-│  ^^^^^^^^^ list-tail expects at least 3
-elements in the list, found: 0
+  │  ^^^^^^^^^ list-tail expects at least 3
+                    elements in the list, found: 0
 ```
 ### **list?**
 Returns true if the value is a list.
@@ -2024,10 +2024,10 @@ if the file does not exist
 > (open-input-file "foo-bar.txt") ;; => #<input-port:foo-bar.txt>
 > (open-input-file "file-does-not-exist.txt")
 error[E08]: Io
-┌─ :1:2
-│
+  ┌─ :1:2
+  │
 1 │ (open-input-file "foo-bar.txt")
-│  ^^^^^^^^^^^^^^^ No such file or directory (os error 2)
+  │  ^^^^^^^^^^^^^^^ No such file or directory (os error 2)
 ```
 ### **open-input-string**
 Creates an input port from a string, that will return the string contents.
@@ -2213,7 +2213,7 @@ Returns quotient of dividing numerator by denomintator.
 ### **range**
 Returns a newly allocated list of the elements in the range [n, m) or [0, m) when n is not given.
 
-(range m)   -> (listof int?)
+(range m)   -> (listof int?)  
 (range n m) -> (listof int?)
 
 * n : int?
@@ -2456,12 +2456,12 @@ Returns the rest of the list. Will raise an error if the list is empty.
 ```scheme
 > (rest (list 10 20 30)) ;; => '(20 30)
 > (rest (list 10)) ;; => '()
-> (rest '() )
+> (rest '())
 error[E11]: Generic
-┌─ :1:2
-│
+  ┌─ :1:2
+  │
 1 │ (rest '())
-│  ^^^^ rest expects a non empty list
+  │  ^^^^ rest expects a non empty list
 ```
 ### **reverse**
 Returns a list that has the same elements as `lst`, but in reverse order.
@@ -2499,12 +2499,11 @@ Get the second element of the list. Raises an error if the list does not have an
 
 ```scheme
 > (second '(1 2 3)) ;; => 2
-> (second '())
 error[E11]: Generic
-┌─ :1:2
-│
+  ┌─ :1:2
+  │
 1 │ (second '())
-│  ^^^^^^ second: index out of bounds - list did not have an element in the second position: []
+  │  ^^^^^^ second: index out of bounds - list did not have an element in the second position: []
 ```
 ### **set-tls!**
 Set the value in the the thread local storage. Only this thread will see the updates associated
@@ -3042,10 +3041,10 @@ Get the third element of the list. Raises an error if the list does not have an 
 > (third '(1 2 3)) ;; => 3
 > (third '())
 error[E11]: Generic
-┌─ :1:2
-│
+  ┌─ :1:2
+  │
 1 │ (third '())
-│  ^^^^^^ third: index out of bounds - list did not have an element in the second position: []
+  │  ^^^^^ third: Index out of bounds - list did not have an element in the second position: []
 ```
 ### **thread-finished?**
 Check if the given thread is finished running.

--- a/docs/src/builtins/steel_lists.md
+++ b/docs/src/builtins/steel_lists.md
@@ -62,10 +62,10 @@ Returns the rest of the list. Will raise an error if the list is empty.
 > (cdr (list 10)) ;; => '()
 > (cdr '())
 error[E11]: Generic
-┌─ :1:2
-│
+  ┌─ :1:2
+  │
 1 │ (cdr '())
-│  ^^^ cdr expects a non empty list
+  │  ^^^ cdr expects a non empty list
 ```
 ### **cons**
 Returns a newly allocated list whose first element is `a` and second element is `d`.
@@ -183,10 +183,10 @@ time complexity is O(n/64). Meaning, for small lists this can be constant.
 > (list-ref (range 0 100) 42) ;; => 42"
 > (list-ref (list 1 2 3 4) 10)
 error[E11]: Generic
-┌─ :1:2
-│
+  ┌─ :1:2
+  │
 1 │ (list-ref (list 1 2 3 4) 10)
-│  ^^^^^^^^ out of bounds index in list-ref - list length: 4, index: 10
+  │  ^^^^^^^^ out of bounds index in list-ref - list length: 4, index: 10
 ```
 ### **list-tail**
 Same as `list-drop`, except raise an error if `n` is greater than the length of `lst`.
@@ -201,11 +201,11 @@ Same as `list-drop`, except raise an error if `n` is greater than the length of 
 > (list-tail '(1 2 3 4 5) 2) ;; => '(3 4 5)
 > (list-tail '() 3)
 error[E11]: Generic
-┌─ :1:2
-│
+  ┌─ :1:2
+  │
 1 │ (list-tail '() 3)
-│  ^^^^^^^^^ list-tail expects at least 3
-elements in the list, found: 0
+  │  ^^^^^^^^^ list-tail expects at least 3
+                    elements in the list, found: 0
 ```
 ### **pair?**
 Checks if the given value can be treated as a pair.
@@ -222,7 +222,7 @@ Checks if the given value can be treated as a pair.
 ### **range**
 Returns a newly allocated list of the elements in the range [n, m) or [0, m) when n is not given.
 
-(range m)   -> (listof int?)
+(range m)   -> (listof int?)  
 (range n m) -> (listof int?)
 
 * n : int?
@@ -243,12 +243,12 @@ Returns the rest of the list. Will raise an error if the list is empty.
 ```scheme
 > (rest (list 10 20 30)) ;; => '(20 30)
 > (rest (list 10)) ;; => '()
-> (rest '() )
+> (rest '())
 error[E11]: Generic
-┌─ :1:2
-│
+  ┌─ :1:2
+  │
 1 │ (rest '())
-│  ^^^^ rest expects a non empty list
+  │  ^^^^ rest expects a non empty list
 ```
 ### **reverse**
 Returns a list that has the same elements as `lst`, but in reverse order.
@@ -273,12 +273,11 @@ Get the second element of the list. Raises an error if the list does not have an
 
 ```scheme
 > (second '(1 2 3)) ;; => 2
-> (second '())
 error[E11]: Generic
-┌─ :1:2
-│
+  ┌─ :1:2
+  │
 1 │ (second '())
-│  ^^^^^^ second: index out of bounds - list did not have an element in the second position: []
+  │  ^^^^^^ second: index out of bounds - list did not have an element in the second position: []
 ```
 ### **take**
 Returns the first n elements of the list l as a new list.
@@ -306,10 +305,10 @@ Get the third element of the list. Raises an error if the list does not have an 
 > (third '(1 2 3)) ;; => 3
 > (third '())
 error[E11]: Generic
-┌─ :1:2
-│
+  ┌─ :1:2
+  │
 1 │ (third '())
-│  ^^^^^^ third: index out of bounds - list did not have an element in the second position: []
+  │  ^^^^^ third: Index out of bounds - list did not have an element in the second position: []
 ```
 ### **cdr-null?**
 ### **list->vector**

--- a/docs/src/builtins/steel_ports.md
+++ b/docs/src/builtins/steel_ports.md
@@ -49,10 +49,10 @@ if the file does not exist
 > (open-input-file "foo-bar.txt") ;; => #<input-port:foo-bar.txt>
 > (open-input-file "file-does-not-exist.txt")
 error[E08]: Io
-┌─ :1:2
-│
+  ┌─ :1:2
+  │
 1 │ (open-input-file "foo-bar.txt")
-│  ^^^^^^^^^^^^^^^ No such file or directory (os error 2)
+  │  ^^^^^^^^^^^^^^^ No such file or directory (os error 2)
 ```
 ### **open-input-string**
 Creates an input port from a string, that will return the string contents.

--- a/docs/src/builtins/steel_transducers.md
+++ b/docs/src/builtins/steel_transducers.md
@@ -7,9 +7,9 @@ Compose multiple iterators into one iterator
 #### Examples
 ```scheme
 (compose
-(mapping (λ (x) (+ x 1)))
-(filtering odd?)
-(taking 15))
+    (mapping (λ (x) (+ x 1)))
+    (filtering odd?)
+    (taking 15))
 ```
 ### **dropping**
 Creates a taking iterator combinator


### PR DESCRIPTION
previously steel-derive would trim all spaces at the start of each line, making it impossible to have indentation in the examples, as that would be stripped away:

<img width="684" height="403" alt="image" src="https://github.com/user-attachments/assets/2e8c45eb-ed5e-4d37-8c4c-175d95952411" />

additionally it was impossible to do a markdown line-break, as all trailing spaces are stripped as well