### PR TITLE
validate macro templates

### DIFF
--- a/crates/steel-core/src/parser/expander.rs
+++ b/crates/steel-core/src/parser/expander.rs
@@ -25,6 +25,7 @@ use smallvec::SmallVec;
 use steel_parser::tokens::IntLiteral;
 use steel_parser::tokens::NumberLiteral;
 
+use super::macro_template::MacroTemplate;
 use super::{ast::Quote, interner::InternedString, parser::Parser};
 
 // Given path, update the extension
@@ -203,15 +204,13 @@ impl SteelMacro {
             .atom_identifier_or_else(throw!(BadSyntax => "macros only currently support
                     identifiers as the name"; ast_macro.location.span))?;
 
-        let sp = ast_macro.location.span;
-
         let special_forms = ast_macro
             .syntax_rules
             .syntax
             .into_iter()
             .map(|x| {
                 x.atom_identifier_or_else(
-                    throw!(BadSyntax => format!("macros only support identifiers for special syntax, found: {}", x); sp),
+                    throw!(BadSyntax => format!("macros only support identifiers for special syntax, found: {}", x); x.span()),
                 )
                 .cloned()
             })
@@ -314,6 +313,13 @@ pub struct MacroCase {
     pub(crate) body: ExprKind,
 }
 
+struct PatternContext<'a> {
+    name: InternedString,
+    special_forms: &'a [InternedString],
+    bindings: FxHashMap<InternedString, u8>,
+    depth: u8,
+}
+
 impl MacroCase {
     #[cfg(test)]
     pub fn new(args: PatternList, body: ExprKind) -> Self {
@@ -355,34 +361,31 @@ impl MacroCase {
     ) -> Result<Self> {
         let PatternPair { pattern, mut body } = pattern_pair;
 
-        let mut bindings = FxHashSet::default();
+        let mut ctx = PatternContext {
+            name: *name,
+            special_forms,
+            bindings: Default::default(),
+            depth: 0,
+        };
 
         let ((mut args, macro_keyword), improper) = if let ExprKind::List(l) = pattern {
             let improper = l.improper;
 
-            (
-                MacroPattern::parse_from_list(l, name, special_forms, &mut bindings, true)?,
-                improper,
-            )
+            (MacroPattern::parse_from_list(l, &mut ctx, true)?, improper)
         } else {
             stop!(Generic => "unable to parse macro");
         };
 
         if let Some(macro_keyword) = macro_keyword {
-            bindings.remove(&macro_keyword);
+            ctx.bindings.remove(&macro_keyword);
         };
 
-        let args_str: SmallVec<[_; 8]> = bindings.iter().copied().collect();
-
-        // dbg!(args_str.iter().map(|x| x.resolve()).collect::<Vec<_>>());
-
-        // let syntaxes: Vec<&str> = args
-        //     .iter()
-        //     .map(|x| x.deconstruct_syntax())
-        //     .flatten()
-        //     .collect();
+        let args_str: SmallVec<[_; 8]> = ctx.bindings.keys().copied().collect();
 
         // TODO: @Matt - if the
+        let template_parser = MacroTemplate::new(ctx.bindings);
+        template_parser.verify(&body)?;
+
         RenameIdentifiersVisitor::new(&args_str, special_forms).rename_identifiers(&mut body);
 
         args.iter_mut().for_each(|x| x.mangle(special_forms));
@@ -550,9 +553,7 @@ impl MacroPattern {
 
     fn parse_from_list(
         list: List,
-        macro_name: &InternedString,
-        special_forms: &[InternedString],
-        bindings: &mut FxHashSet<InternedString>,
+        ctx: &mut PatternContext,
         top_level: bool,
     ) -> Result<(Vec<MacroPattern>, Option<InternedString>)> {
         let mut pattern_vec: Vec<MacroPattern> = Vec::with_capacity(4);
@@ -563,8 +564,8 @@ impl MacroPattern {
         let wildcard = InternedString::from_static("_");
 
         macro_rules! add_binding {
-            ($key:expr, $span:expr) => {
-                if $key != wildcard && !bindings.insert($key) {
+            ($key:expr, $span:expr, $many:expr) => {
+                if $key != wildcard && ctx.bindings.insert($key, ctx.depth + if $many { 1 } else { 0 }).is_some() {
                     let var = $key.resolve();
                     stop!(BadSyntax => "repeated pattern variable {}", var ; $span);
                 }
@@ -572,15 +573,49 @@ impl MacroPattern {
         }
 
         macro_rules! check_ellipsis {
-            ($improper:expr, $span:expr) => {
+            ($last:expr, $span:expr) => {
                 if ellipsis {
                     stop!(BadSyntax => "pattern with more than one ellipsis"; $span);
-                } else if $improper {
+                } else if list.improper && $last {
                     stop!(BadSyntax => "ellipsis cannot appear as list tail"; $span);
                 }
 
                 ellipsis = true;
             }
+        }
+
+        macro_rules! parse_nested {
+            ($list:expr, $index:expr, $vec:expr) => {{
+                let ellipsis_span = exprs_iter
+                    .peek()
+                    .and_then(|(_, expr)| expr.atom_syntax_object())
+                    .filter(|syn| syn.ty == TokenType::Ellipses)
+                    .map(|syn| syn.span);
+
+                if ellipsis_span.is_some() {
+                    ctx.depth += 1;
+                }
+
+                let improper = $list.improper;
+                let (patterns, _) = Self::parse_from_list($list, ctx, false)?;
+
+                if let Some(span) = ellipsis_span {
+                    let _ = exprs_iter.next();
+
+                    ctx.depth -= 1;
+
+                    check_ellipsis!($index + 2 == len, span);
+                }
+
+                let nested =
+                    MacroPattern::Nested(PatternList::new(patterns).with_improper(improper), $vec);
+
+                if ellipsis_span.is_some() {
+                    MacroPattern::Many(nested.into())
+                } else {
+                    nested
+                }
+            }};
         }
 
         let mut macro_keyword = None;
@@ -591,7 +626,7 @@ impl MacroPattern {
                     syn: SyntaxObject { ty: s, span, .. },
                 }) => match s {
                     TokenType::Identifier(t) => {
-                        if t == *macro_name || special_forms.contains(&t) {
+                        if t == ctx.name || ctx.special_forms.contains(&t) {
                             pattern_vec.push(MacroPattern::Syntax(t))
                         } else {
                             let peek = exprs_iter.peek().map(|(_, expr)| expr);
@@ -622,8 +657,7 @@ impl MacroPattern {
                             };
 
                             if let Some(span) = ellipsis_span {
-                                let last_proper = list.improper && i + 2 == len;
-                                check_ellipsis!(last_proper, span);
+                                check_ellipsis!(i + 2 == len, span);
 
                                 exprs_iter.next();
 
@@ -631,14 +665,14 @@ impl MacroPattern {
                                     stop!(BadSyntax => "macro name cannot be followed by ellipsis"; span);
                                 }
 
-                                add_binding!(t, span);
+                                add_binding!(t, span, true);
                                 pattern_vec.push(MacroPattern::Many(MacroPattern::Single(t).into()))
                             } else {
                                 if i == 0 && top_level {
                                     macro_keyword = Some(t);
                                 }
 
-                                add_binding!(t, span);
+                                add_binding!(t, span, false);
                                 pattern_vec.push(MacroPattern::Single(t));
                             }
                         }
@@ -711,17 +745,12 @@ impl MacroPattern {
                         }
                     }
                     TokenType::Ellipses => {
+                        check_ellipsis!(i + 1 == len, span);
+
                         let last = pattern_vec.pop();
 
                         match last {
-                            Some(MacroPattern::Nested(inner, vec)) => {
-                                let improper = list.improper && i + 1 == len;
-                                check_ellipsis!(improper, span);
-
-                                pattern_vec.push(MacroPattern::Many(
-                                    MacroPattern::Nested(inner, vec).into(),
-                                ));
-                            }
+                            Some(MacroPattern::Nested(..)) => unreachable!(),
 
                             Some(
                                 pat @ (MacroPattern::BytesLiteral(..)
@@ -746,14 +775,9 @@ impl MacroPattern {
                     }
                 },
                 ExprKind::List(l) => {
-                    let improper = l.improper;
-                    let (patterns, _) =
-                        Self::parse_from_list(l, macro_name, special_forms, bindings, false)?;
+                    let nested = parse_nested![l, i, false];
 
-                    pattern_vec.push(MacroPattern::Nested(
-                        PatternList::new(patterns).with_improper(improper),
-                        false,
-                    ))
+                    pattern_vec.push(nested)
                 }
                 ExprKind::Quote(q) => pattern_vec.push(MacroPattern::QuotedExpr(q)),
                 ExprKind::Vector(Vector {
@@ -761,10 +785,9 @@ impl MacroPattern {
                 }) => {
                     let list = List::new(args);
 
-                    let (patterns, _) =
-                        Self::parse_from_list(list, macro_name, special_forms, bindings, false)?;
+                    let nested = parse_nested![list, i, true];
 
-                    pattern_vec.push(MacroPattern::Nested(PatternList::new(patterns), true))
+                    pattern_vec.push(nested)
                 }
                 ExprKind::Vector(v @ Vector { bytes: true, .. }) => {
                     let bytes = v.as_bytes().collect();

--- a/crates/steel-core/src/parser/macro_template.rs
+++ b/crates/steel-core/src/parser/macro_template.rs
@@ -1,0 +1,132 @@
+use std::ops::ControlFlow;
+
+use fxhash::FxHashMap;
+use steel_parser::{
+    ast::{Atom, ExprKind, List, Vector},
+    interner::InternedString,
+    parser::SyntaxObject,
+    tokens::TokenType,
+};
+
+use crate::{compiler::passes::VisitorMutControlFlow, SteelErr};
+
+pub struct MacroTemplate {
+    bindings: FxHashMap<InternedString, u8>,
+    depth: u8,
+    result: Result<(), SteelErr>,
+}
+
+impl MacroTemplate {
+    pub fn new(bindings: FxHashMap<InternedString, u8>) -> Self {
+        Self {
+            bindings,
+            depth: 0,
+            result: Ok(()),
+        }
+    }
+
+    pub fn verify(mut self, expr: &ExprKind) -> Result<(), SteelErr> {
+        let _ = self.visit(expr);
+
+        self.result
+    }
+
+    fn visit_list_elements(
+        &mut self,
+        elements: &[ExprKind],
+        improper: bool,
+        vec: bool,
+    ) -> ControlFlow<()> {
+        let mut iter = elements.iter().enumerate().peekable();
+        let len = elements.len();
+
+        while let Some((i, expr)) = iter.next() {
+            let ellipsis =
+                expr.atom_syntax_object().map(|syn| syn.ty.clone()) == Some(TokenType::Ellipses);
+
+            // special case: (... expr)
+            if i == 0 && len == 2 && ellipsis && !improper && !vec {
+                let (_, next) = iter.next().unwrap();
+
+                self.visit(next)?;
+
+                return ControlFlow::Continue(());
+            }
+
+            let atom_peek = iter.peek().and_then(|(_, expr)| expr.atom_syntax_object());
+
+            let is_many = if let Some(SyntaxObject {
+                ty: TokenType::Ellipses,
+                span,
+                ..
+            }) = atom_peek
+            {
+                if improper && i + 2 == len {
+                    self.result =
+                        steelerr![BadSyntax => "ellipsis cannot appear as list tail"; *span];
+                }
+
+                true
+            } else {
+                false
+            };
+
+            if is_many {
+                self.depth += 1;
+            }
+
+            self.visit(expr)?;
+
+            if is_many {
+                self.depth -= 1;
+
+                let _ = iter.next();
+            }
+        }
+
+        ControlFlow::Continue(())
+    }
+}
+
+impl VisitorMutControlFlow for MacroTemplate {
+    #[inline]
+    fn visit_list(&mut self, l: &List) -> ControlFlow<()> {
+        self.visit_list_elements(&l.args, l.improper, false)
+    }
+
+    #[inline]
+    fn visit_vector(&mut self, v: &Vector) -> ControlFlow<()> {
+        if v.bytes {
+            return ControlFlow::Continue(());
+        }
+
+        self.visit_list_elements(&v.args, false, true)
+    }
+
+    #[inline]
+    fn visit_atom(&mut self, atom: &Atom) -> ControlFlow<()> {
+        if atom.syn.ty == TokenType::Ellipses {
+            self.result = steelerr![BadSyntax => "ellipses are not a valid identifier in templates"; atom.syn.span];
+            return ControlFlow::Break(());
+        }
+
+        let Some(ident) = atom.ident() else {
+            return ControlFlow::Continue(());
+        };
+
+        let Some(pattern_depth) = self.bindings.get(ident).copied() else {
+            return ControlFlow::Continue(());
+        };
+
+        if pattern_depth > self.depth {
+            let missing = pattern_depth - self.depth;
+            let name = if missing > 1 { "ellipses" } else { "ellipsis" };
+
+            self.result = steelerr![BadSyntax => format!("missing {}: pattern variable needs at least {} levels of repetition, found {}", name, pattern_depth, self.depth);  atom.syn.span];
+
+            return ControlFlow::Break(());
+        }
+
+        ControlFlow::Continue(())
+    }
+}

--- a/crates/steel-core/src/parser/mod.rs
+++ b/crates/steel-core/src/parser/mod.rs
@@ -15,5 +15,6 @@ pub mod tokens;
 pub mod tryfrom_visitor;
 pub mod visitors;
 
+mod macro_template;
 #[cfg(test)]
 mod prop;


### PR DESCRIPTION
Statically validates templates in syntax patterns to have the appropriate depth of ellipses/repetition.

This is not necessarily mandated by R7RS, but both Racket and Guile do validate this statically, and I think it just makes sense. This allows us to print some fancy error messages:
```
λ > (define-syntax foo (syntax-rules () [(_ (a ...) ...) (a ...)]))
error[E06]: BadSyntax
  ┌─ :1:55
  │
1 │ (define-syntax foo (syntax-rules () [(_ (a ...) ...) (a ...)]))
  │                                                       ^ missing ellipsis: pattern variable needs at least 2 levels of repetition, found 1
```