### PR TITLE
Implement LSP function to list symbols in current document

### DIFF
--- a/crates/steel-core/src/compiler/passes/analysis.rs
+++ b/crates/steel-core/src/compiler/passes/analysis.rs
@@ -2890,7 +2890,11 @@ impl<'a> VisitorMutUnitRef<'a> for FindContextsWithOffset<'a> {
 
             span.start = define.location.span.start;
 
-            log::debug!("Defined function span: {:?} - offset: {}", span, self.offset);
+            log::debug!(
+                "Defined function span: {:?} - offset: {}",
+                span,
+                self.offset
+            );
 
             if span.range().contains(&(self.offset as u32)) {
                 if let Some(info) = self.analysis.get_function_info(lambda_function) {
@@ -2996,9 +3000,10 @@ impl<'a> VisitorMutUnitRef<'a> for TopLevelDefinitionFinder<'a> {
                 self.definitions.push((name, kind.clone(), info.span));
             } else {
                 let kind = &expr.body;
-                let name= *a.ident().unwrap_or(&InternedString::from_str("unknown"));
+                let name = *a.ident().unwrap_or(&InternedString::from_str("unknown"));
 
-                self.definitions.push((name, kind.clone(), expr.location.span));
+                self.definitions
+                    .push((name, kind.clone(), expr.location.span));
             }
         }
     }


### PR DESCRIPTION
Implement crude top-level symbol definition lookup in file - currently distinguishes top-level constants, top-level functions and `let` bindings.

For testing, I used [`flash.hx`](https://github.com/shybovycha/flash.hx/blob/master/flash.scm):

<img width="1704" height="964" alt="Screenshot 2025-11-02 at 7 47 58 pm" src="https://github.com/user-attachments/assets/d223c7e9-f617-4df0-bd73-7aef69f7cf45" />
