### PR TITLE
Cleanup document symbols

### DIFF
--- a/crates/steel-language-server/src/main.rs
+++ b/crates/steel-language-server/src/main.rs
@@ -133,6 +133,7 @@ async fn main() {
         vfs,
         root,
         ast_map: DashMap::new(),
+        raw_ast_map: DashMap::new(),
         lowered_ast_map: DashMap::new(),
         document_map: DashMap::new(),
         _macro_map: DashMap::new(),


### PR DESCRIPTION
Traverse raw AST to find all the `let*` bindings. This way the AST does not contain non-existent tokens from expanding macros (such as `or` and `let*`).

<img width="1706" height="970" alt="Screenshot 2025-11-05 at 11 27 46 pm" src="https://github.com/user-attachments/assets/855d1472-4dcc-43ad-8348-e42be364820d" />
