### PR TITLE
implement `memf`, `assf` and `findf` procedures

### DIFF
--- a/crates/steel-core/src/scheme/stdlib.scm
+++ b/crates/steel-core/src/scheme/stdlib.scm
@@ -44,6 +44,7 @@
          assq
          assv
          assf
+         findf
          filter
          even-rec?
          odd-rec?
@@ -1000,6 +1001,32 @@
     [(null? lst) #f]
     [(proc (car (car lst))) (car lst)]
     [else (assf proc (cdr lst))]))
+
+;;@doc
+;; Returns the first element of the list, where the given proc returns a true
+;; value, when applied to it. Returns `#f`, if no element is found.
+;;
+;; If `#f` is an element of *lst*, a return value of `#f` is ambiguous: it
+;; might indicate that no element satisfies *proc* or it may indicate, that
+;; `#f` satisfies *proc*.
+;;
+;; (findf proc lst) -> (or/c any/c #f)
+;;
+;; - proc : procedure?
+;; - lst: list?
+;;
+;; # Examples
+;;
+;; ```scheme
+;; (findf odd? '(0 2 1 3 4)) ;; => 1
+;; (findf (λ (x) (char-ci=? #\D x)) '(#\a #\b #\c #\d #\e)) ;; => #\d
+;; (findf (λ (x) (> x 5)) '(0 2 1 3 4)) ;; => #f
+;; ```
+(define (findf proc lst)
+  (cond
+    [(null? lst) #f]
+    [(proc (car lst)) (car lst)]
+    [else (findf proc (cdr lst))]))
 
 ;;@doc
 ;; Returns new list, keeping elements from `lst` which applying `pred` to the element

--- a/docs/src/stdlib/private_steel_stdlib.md
+++ b/docs/src/stdlib/private_steel_stdlib.md
@@ -129,6 +129,26 @@ returns #t.
 ```scheme
 (filter even? (range 0 5)) ;; '(0 2 4)
 ```
+### **findf**
+Returns the first element of the list, where the given proc returns a true
+value, when applied to it. Returns `#f`, if no element is found.
+
+If `#f` is an element of *lst*, a return value of `#f` is ambiguous: it
+might indicate that no element satisfies *proc* or it may indicate, that
+`#f` satisfies *proc*.
+
+(findf proc lst) -> (or/c any/c #f)
+
+- proc : procedure?
+- lst: list?
+
+#### Examples
+
+```scheme
+(findf odd? '(0 2 1 3 4)) ;; => 1
+(findf (λ (x) (char-ci=? #\D x)) '(#\a #\b #\c #\d #\e)) ;; => #\d
+(findf (λ (x) (> x 5)) '(0 2 1 3 4)) ;; => #f
+```
 ### **flatten**
 Recursively flatten an arbitray structure of pairs into a single list.
 


### PR DESCRIPTION
`memf` and `assf` are versions of `member` and `assoc` respectively, that take a procedure instead of a value to compare against. the `findf` procedure is similar to `memf`, but it returns the item itself instead of a list where the item is the car.

i needed this in my `helix.scm` file, where i have the following code:

```scheme
(define rust-analyzer
    (findf (λ (client) (string=? (lsp-client-name client) "rust-analyzer")) (get-active-lsp-clients)))
```

and i implemented `findf` myself (since it isn't hard), but i thought, maybe i could upstream it and maybe add some more procedures (i needed `memf` like a few months ago, forgot for what).

(the names are stolen from racket.)