### PR TITLE
Docs: Fix typo documentation for `dropping`

### DIFF
--- a/docs/src/builtins/steel_transducers.md
+++ b/docs/src/builtins/steel_transducers.md
@@ -12,7 +12,7 @@ Compose multiple iterators into one iterator
     (taking 15))
 ```
 ### **dropping**
-Creates a taking iterator combinator
+Creates a dropping iterator combinator
 
 (dropping integer?) -> iterator?
 


### PR DESCRIPTION
Just noticed a minor mistake in the docs. Easy to fix!