### PR TITLE
Fix spelling error in macros.md

### DIFF
--- a/docs/src/reference/spelling error
+++ b/docs/src/reference/spelling error
@@ -1,6 +1,6 @@
 # Macros
 
-Steel contains a an implementation of `syntax-rules` and `syntax-case` that scheme provides. These macros build on the small primary language constructs that exist. Consider the following:
+Steel contains an implementation of `syntax-rules` and `syntax-case` that scheme provides. These macros build on the small primary language constructs that exist. Consider the following:
 
 ```scheme
 (define-syntax or


### PR DESCRIPTION
I was reading the documentation and noticed this spelling error. Thought I should fix it.