### PR TITLE
Fix spellcheck.scm example.

### DIFF
--- a/examples/scripts/spellcheck.scm
+++ b/examples/scripts/spellcheck.scm
@@ -78,7 +78,7 @@
 ;; otherwise returns the trimmed word
 (define (get-next-word!)
   (define line (read-line-from-port *corpus-port*))
-  (if (symbol? line)
+  (if (or (eof-object? line) (symbol? line))
       #f
       (trim line)))
 


### PR DESCRIPTION
Previously, when trying to run the `spellcheck` example, right before the repl launched, the following error popped up:

```
Generating the bk tree
error[E03]: TypeMismatch
   ┌─ spellcheck.rkt:83:8
   │
83 │       (trim line)))
   │        ^^^^ trim: Cannot convert steel value: (eof) to steel string
```

This just updates the `get-next-word` function in the example to see if `line` is an eof object.