### PR TITLE
Add std feature gates and no_std entry points

### DIFF
--- a/crates/steel-core/Cargo.toml
+++ b/crates/steel-core/Cargo.toml
@@ -124,7 +124,8 @@ criterion = "0.5.1"
 
 [features]
 # TODO: Deprecate the modules feature flag, it no longer does anything
-default = ["modules"]
+default = ["std", "modules"]
+std = []
 modules = []
 jit = ["dep:cranelift", "dep:cranelift-module", "dep:cranelift-jit"]
 sandbox = []

--- a/crates/steel-core/src/lib.rs
+++ b/crates/steel-core/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
 extern crate alloc;
 extern crate im_rc;
 #[macro_use]

--- a/crates/steel-gen/Cargo.toml
+++ b/crates/steel-gen/Cargo.toml
@@ -12,3 +12,7 @@ description = "Code generation crates for use within steel"
 [dependencies]
 codegen = "0.2.0"
 serde = { version = "1.0.152", features = ["derive"] }
+
+[features]
+default = ["std"]
+std = []

--- a/crates/steel-gen/src/lib.rs
+++ b/crates/steel-gen/src/lib.rs
@@ -1,2 +1,4 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
 pub mod opcode;
 pub use opcode::OpCode;

--- a/crates/steel-parser/Cargo.toml
+++ b/crates/steel-parser/Cargo.toml
@@ -22,5 +22,9 @@ smallvec = "1.13"
 compact_str = "0.8.0"
 log = "0.4.17"
 
+[features]
+default = ["std"]
+std = []
+
 [dev-dependencies]
 pretty_assertions = "1.4" # Only used by unit tests.

--- a/crates/steel-parser/src/lib.rs
+++ b/crates/steel-parser/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
 extern crate alloc;
 
 pub mod ast;


### PR DESCRIPTION
This PR adds only the feature-gate scaffolding for upcoming no_std work as per [#535 ](https://github.com/mattwparas/steel/issues/535) . It introduces std feature flags (defaulted on) and #![cfg_attr(not(feature = "std"), no_std)] at crate roots. No shims or code migrations are included, and behavior remains unchanged with default features.

Changes:

- Added std features (default) to steel-core, steel-parser, and steel-gen.
- Added #![cfg_attr(not(feature = "std"), no_std)] in lib.rs for those crates.
- No functional changes; std remains the default build mode.

Tests: cargo test --all -> ok

QUESTION: There is a "modules" feature in steel-core which seems to be unused. Do we want to deprecate it as per TODO? 