### PR TITLE
no_std: add time abstraction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3885,6 +3885,7 @@ dependencies = [
  "im",
  "im-lists",
  "im-rc",
+ "js-sys",
  "lasso",
  "log",
  "md-5",

--- a/crates/steel-core/Cargo.toml
+++ b/crates/steel-core/Cargo.toml
@@ -43,7 +43,7 @@ steel-gen = { path = "../steel-gen", version = "0.3.0" }
 steel-parser = { path = "../steel-parser", version = "0.7.0" }
 steel-derive = { path = "../steel-derive", version = "0.6.0" }
 cargo-steel-lib = { path = "../cargo-steel-lib", version = "0.2.0", optional = true }
-chrono = { version = "0.4.23", default-features = false, features = ["std", "clock"] }
+chrono = { version = "0.4.23", default-features = false, features = ["std", "clock"], optional = true }
 env_home = "0.1.0"
 weak-table = "0.3.2"
 # TODO: Consider whether rand needs to be here
@@ -111,6 +111,7 @@ icu_casemap = "2.0.0"
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 getrandom = { version = "0.3.1", features = ["wasm_js"] }
+js-sys = "0.3.69"
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 polling = "3.10.0"
@@ -125,7 +126,7 @@ criterion = "0.5.1"
 [features]
 # TODO: Deprecate the modules feature flag, it no longer does anything
 default = ["std", "modules"]
-std = []
+std = ["dep:chrono"]
 modules = []
 jit = ["dep:cranelift", "dep:cranelift-module", "dep:cranelift-jit"]
 sandbox = []

--- a/crates/steel-core/src/compiler/compiler.rs
+++ b/crates/steel-core/src/compiler/compiler.rs
@@ -61,7 +61,7 @@ use super::{
 use crate::values::HashMap as ImmutableHashMap;
 
 #[cfg(feature = "profiling")]
-use std::time::Instant;
+use crate::time::Instant;
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Debug)]
 enum DefineKind {

--- a/crates/steel-core/src/compiler/modules.rs
+++ b/crates/steel-core/src/compiler/modules.rs
@@ -42,7 +42,7 @@ use std::{
 use crate::parser::expander::SteelMacro;
 use crate::stop;
 
-use std::time::SystemTime;
+use crate::time::SystemTime;
 
 use crate::parser::expand_visitor::{expand, extract_macro_defs};
 
@@ -59,7 +59,7 @@ use super::{
 macro_rules! time {
     ($label:expr, $e:expr) => {{
         #[cfg(feature = "profiling")]
-        let now = std::time::Instant::now();
+        let now = crate::time::Instant::now();
 
         let e = $e;
 
@@ -2064,7 +2064,7 @@ impl CompiledModuleCache {
             BACKGROUND_DESERIALIZING.1.send(key).unwrap();
         }
 
-        let now = std::time::Instant::now();
+        let now = crate::time::Instant::now();
 
         if let Some(cache_dir) = &self.cache_dir {
             let key = Self::create_key(cache_dir, path);
@@ -2552,7 +2552,7 @@ impl<'a> ModuleBuilder<'a> {
 
         //         module.set_emitted(true);
 
-        //         let top_level_time = std::time::Instant::now();
+        //         let top_level_time = crate::time::Instant::now();
 
         //         let res = module.to_top_level_module(&modules, self.global_macro_map);
 
@@ -2909,7 +2909,7 @@ impl<'a> ModuleBuilder<'a> {
     // I think these will already be collected for the macro, however I think for syntax should be found earlier
     // Otherwise the macro expansion will not be able to understand it
     fn collect_provides(&mut self) -> Result<()> {
-        // let now = std::time::Instant::now();
+        // let now = crate::time::Instant::now();
 
         let mut non_provides = Vec::with_capacity(self.source_ast.len());
         let exprs = core::mem::take(&mut self.source_ast);
@@ -3432,7 +3432,7 @@ impl<'a> ModuleBuilder<'a> {
 
     fn parse_builtin(mut self, input: Cow<'static, str>) -> Result<Self> {
         #[cfg(feature = "profiling")]
-        let now = std::time::Instant::now();
+        let now = crate::time::Instant::now();
 
         let id = self
             .sources

--- a/crates/steel-core/src/compiler/passes/analysis.rs
+++ b/crates/steel-core/src/compiler/passes/analysis.rs
@@ -357,7 +357,7 @@ impl Analysis {
         self.clear();
 
         #[cfg(feature = "profiling")]
-        let now = std::time::Instant::now();
+        let now = crate::time::Instant::now();
 
         self.run(exprs);
 
@@ -5276,7 +5276,7 @@ impl<'a> SemanticAnalysis<'a> {
         table: &mut FxHashSet<InternedString>,
     ) -> &mut Self {
         #[cfg(feature = "profiling")]
-        let now = std::time::Instant::now();
+        let now = crate::time::Instant::now();
 
         let mut replacer =
             ReplaceBuiltinUsagesWithReservedPrimitiveReferences::new(&self.analysis, table);
@@ -5353,7 +5353,7 @@ impl<'a> SemanticAnalysis<'a> {
         module_manager: &ModuleManager,
     ) -> &mut Self {
         #[cfg(feature = "profiling")]
-        let now = std::time::Instant::now();
+        let now = crate::time::Instant::now();
 
         let module_get_interned: InternedString = "%module-get%".into();
         let proto_hash_get: InternedString = "%proto-hash-get%".into();
@@ -5704,7 +5704,7 @@ impl<'a> SemanticAnalysis<'a> {
 
     pub fn replace_anonymous_function_calls_with_plain_lets(&mut self) -> &mut Self {
         #[cfg(feature = "profiling")]
-        let now = std::time::Instant::now();
+        let now = crate::time::Instant::now();
 
         let mut re_run_analysis = false;
 

--- a/crates/steel-core/src/compiler/passes/begin.rs
+++ b/crates/steel-core/src/compiler/passes/begin.rs
@@ -12,7 +12,7 @@ use crate::parser::{
 use crate::parser::{interner::InternedString, tokens::TokenType};
 
 #[cfg(feature = "profiling")]
-use std::time::Instant;
+use crate::time::Instant;
 
 use super::{VisitorMutRefUnit, VisitorMutUnit};
 

--- a/crates/steel-core/src/compiler/program.rs
+++ b/crates/steel-core/src/compiler/program.rs
@@ -20,10 +20,12 @@ use crate::{
     rvals::IntoSteelVal,
 };
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, time::SystemTime};
+use std::collections::HashMap;
+
+use crate::time::SystemTime;
 
 #[cfg(feature = "profiling")]
-use std::time::Instant;
+use crate::time::Instant;
 
 #[cfg(feature = "profiling")]
 use log::{debug, log_enabled};

--- a/crates/steel-core/src/lib.rs
+++ b/crates/steel-core/src/lib.rs
@@ -8,6 +8,7 @@ mod env;
 pub mod core;
 pub mod compiler;
 pub mod primitives;
+pub mod time;
 #[macro_use]
 pub mod rerrs;
 pub mod rvals;

--- a/crates/steel-core/src/parser/kernel.rs
+++ b/crates/steel-core/src/parser/kernel.rs
@@ -596,7 +596,7 @@ impl Kernel {
         environment: &str,
     ) -> Result<ExprKind> {
         #[cfg(feature = "profiling")]
-        let now = std::time::Instant::now();
+        let now = crate::time::Instant::now();
 
         let span = get_span(&expr);
 

--- a/crates/steel-core/src/parser/tryfrom_visitor.rs
+++ b/crates/steel-core/src/parser/tryfrom_visitor.rs
@@ -269,7 +269,7 @@ pub struct SyntaxObjectFromExprKind {
 
 impl SyntaxObjectFromExprKind {
     pub fn try_from_expr_kind(e: ExprKind) -> Result<SteelVal> {
-        // let now = std::time::Instant::now();
+        // let now = crate::time::Instant::now();
 
         SyntaxObjectFromExprKind {
             _inside_quote: false,

--- a/crates/steel-core/src/primitives/time.rs
+++ b/crates/steel-core/src/primitives/time.rs
@@ -1,10 +1,10 @@
 use crate::gc::Gc;
 use crate::rvals::{as_underlying_type, IntoSteelVal};
+use crate::time::Instant;
+use crate::time::{Duration, SystemTime};
 use crate::SteelVal;
 use crate::{rvals::Custom, steel_vm::builtin::MarkdownDoc};
 use chrono::{Datelike, Local, NaiveDate, NaiveDateTime};
-use std::time::Instant;
-use std::time::{Duration, SystemTime};
 use steel_derive::function;
 
 use crate::steel_vm::builtin::BuiltInModule;
@@ -12,7 +12,7 @@ use crate::steel_vm::register_fn::RegisterFn;
 
 pub(crate) const TIME_MODULE_DOC: MarkdownDoc<'static> = MarkdownDoc::from_str(
     r#"
-Contains direct wrappers around the Rust `std::time::Instant` and `core::time::Duration` modules. 
+Contains direct wrappers around the Rust `crate::time::Instant` and `crate::time::Duration` modules. 
 For example, to measure the time something takes:
 
 ```scheme
@@ -132,7 +132,7 @@ fn sleep_millis(millis: usize) {
 /// (current-milliseconds) -> int?
 #[function(name = "current-milliseconds")]
 fn current_milliseconds() -> SteelVal {
-    use std::time::{SystemTime, UNIX_EPOCH};
+    use crate::time::{SystemTime, UNIX_EPOCH};
 
     match SystemTime::now().duration_since(UNIX_EPOCH) {
         Ok(n) => {
@@ -151,7 +151,7 @@ fn current_milliseconds() -> SteelVal {
 /// (current-second) -> int?
 #[function(name = "current-second")]
 fn current_seconds() -> SteelVal {
-    use std::time::{SystemTime, UNIX_EPOCH};
+    use crate::time::{SystemTime, UNIX_EPOCH};
 
     match SystemTime::now().duration_since(UNIX_EPOCH) {
         Ok(n) => {
@@ -170,7 +170,7 @@ fn current_seconds() -> SteelVal {
 /// (current-inexact-milliseconds) -> inexact?
 #[function(name = "current-inexact-milliseconds")]
 fn current_inexact_milliseconds() -> f64 {
-    use std::time::{SystemTime, UNIX_EPOCH};
+    use crate::time::{SystemTime, UNIX_EPOCH};
 
     match SystemTime::now().duration_since(UNIX_EPOCH) {
         Ok(n) => n.as_secs_f64() * 1000.0,

--- a/crates/steel-core/src/rvals/cycles.rs
+++ b/crates/steel-core/src/rvals/cycles.rs
@@ -1165,7 +1165,7 @@ impl<'a> BreadthFirstSearchSteelValVisitor for IterativeDropHandler<'a> {
 
                     std::thread::spawn(move || {
                         while let Ok(mut value) = receiver.recv() {
-                            // let now = std::time::Instant::now();
+                            // let now = crate::time::Instant::now();
                             value.visit();
                             // println!("Dropping: {:?}", now.elapsed());
                         }

--- a/crates/steel-core/src/steel_vm/dylib.rs
+++ b/crates/steel-core/src/steel_vm/dylib.rs
@@ -203,7 +203,7 @@ impl DylibContainers {
                         }
 
                         log::info!(target: "dylibs", "Loading dylib: {:?}", path);
-                        let now = std::time::Instant::now();
+                        let now = crate::time::Instant::now();
 
                         // Load the module in
                         let (container, max_enum) =

--- a/crates/steel-core/src/steel_vm/engine.rs
+++ b/crates/steel-core/src/steel_vm/engine.rs
@@ -440,7 +440,7 @@ pub fn load_module_noop(target: &crate::rvals::SteelString) -> crate::rvals::Res
 macro_rules! time {
     ($target:expr, $label:expr, $e:expr) => {{
         #[cfg(feature = "profiling")]
-        let now = std::time::Instant::now();
+        let now = crate::time::Instant::now();
 
         let e = $e;
 
@@ -556,9 +556,9 @@ impl Engine {
     pub(crate) fn new_kernel(sandbox: bool) -> Self {
         log::debug!(target:"kernel", "Instantiating a new kernel");
         #[cfg(feature = "profiling")]
-        let mut total_time = std::time::Instant::now();
+        let mut total_time = crate::time::Instant::now();
         #[cfg(feature = "profiling")]
-        let mut now = std::time::Instant::now();
+        let mut now = crate::time::Instant::now();
         let sources = Sources::new();
         let modules = ModuleContainer::with_expected_capacity();
 
@@ -591,7 +591,7 @@ impl Engine {
         // log::debug!(target: "kernel", "Registered modules in the kernel!: {:?}", now.elapsed());
 
         #[cfg(feature = "profiling")]
-        let mut now = std::time::Instant::now();
+        let mut now = crate::time::Instant::now();
 
         let core_libraries = [crate::stdlib::PRELUDE];
 
@@ -1271,7 +1271,7 @@ impl Engine {
         engine.virtual_machine.compiler.write().kernel = Some(Kernel::new());
 
         #[cfg(feature = "profiling")]
-        let now = std::time::Instant::now();
+        let now = crate::time::Instant::now();
 
         if let Err(e) = engine.run(PRELUDE_WITHOUT_BASE) {
             raise_error(&engine.virtual_machine.compiler.read().sources, e);
@@ -1501,7 +1501,7 @@ impl Engine {
         }
 
         #[cfg(feature = "profiling")]
-        let now = std::time::Instant::now();
+        let now = crate::time::Instant::now();
 
         if let Err(e) = engine.run(PRELUDE_WITHOUT_BASE) {
             raise_error(&engine.virtual_machine.compiler.read().sources, e);
@@ -2250,7 +2250,7 @@ impl Engine {
         RwLockReadGuard::map(self.virtual_machine.compiler.read(), |x| x.modules())
     }
 
-    pub fn module_metadata(&self) -> crate::HashMap<PathBuf, std::time::SystemTime> {
+    pub fn module_metadata(&self) -> crate::HashMap<PathBuf, crate::time::SystemTime> {
         self.virtual_machine
             .compiler
             .read()

--- a/crates/steel-core/src/steel_vm/interrupt.rs
+++ b/crates/steel-core/src/steel_vm/interrupt.rs
@@ -1,12 +1,10 @@
-use std::{
-    sync::{
-        atomic::{AtomicBool, Ordering},
-        Arc,
-    },
-    time::Duration,
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
 };
 
 use crate::steel_vm::{engine::Engine, ThreadStateController};
+use crate::time::Duration;
 
 pub struct InterruptHandler {
     controller: ThreadStateController,

--- a/crates/steel-core/src/steel_vm/vm.rs
+++ b/crates/steel-core/src/steel_vm/vm.rs
@@ -63,6 +63,8 @@ use std::sync::Mutex;
 
 use super::engine::EngineId;
 
+#[cfg(feature = "profiling")]
+use crate::time::Instant;
 use crossbeam_utils::atomic::AtomicCell;
 #[cfg(feature = "profiling")]
 use log::{debug, log_enabled};
@@ -70,8 +72,6 @@ use num_bigint::BigInt;
 use num_traits::CheckedSub;
 use parking_lot::RwLock;
 use smallvec::SmallVec;
-#[cfg(feature = "profiling")]
-use std::time::Instant;
 use steel_parser::interner::InternedString;
 use threads::ThreadHandle;
 
@@ -539,7 +539,7 @@ impl Synchronizer {
                     continue;
                 }
 
-                let now = std::time::Instant::now();
+                let now = crate::time::Instant::now();
 
                 // TODO: Have to use a condvar
                 while now.elapsed().as_millis() < timeout_ms {
@@ -2554,7 +2554,7 @@ impl<'a> VmCore<'a> {
 
             // println!("{:?}", self.instructions[self.ip]);
 
-            // let now = std::time::Instant::now();
+            // let now = crate::time::Instant::now();
 
             // TODO -> don't just copy the value from the instructions
             // We don't need to do that... Figure out a way to just take a reference to the value

--- a/crates/steel-core/src/steel_vm/vm/threads.rs
+++ b/crates/steel-core/src/steel_vm/vm/threads.rs
@@ -226,7 +226,7 @@ pub fn closure_into_serializable(
 //     use crate::rvals::SerializableSteelVal;
 
 //     #[cfg(feature = "profiling")]
-//     let now = std::time::Instant::now();
+//     let now = crate::time::Instant::now();
 
 //     // Need a new:
 //     // Stack
@@ -766,7 +766,7 @@ pub(crate) fn spawn_native_thread(ctx: &mut VmCore, args: &[SteelVal]) -> Option
     // We are now in a world in which we have to support safe points
     ctx.thread.safepoints_enabled = true;
 
-    let thread_time = std::time::Instant::now();
+    let thread_time = crate::time::Instant::now();
 
     // Do this here?
     let mut thread = ctx.thread.clone();

--- a/crates/steel-core/src/time.rs
+++ b/crates/steel-core/src/time.rs
@@ -1,0 +1,350 @@
+#![cfg_attr(not(feature = "std"), allow(dead_code))]
+
+#[cfg(feature = "std")]
+pub use std::time::{Duration, Instant, SystemTime, SystemTimeError, UNIX_EPOCH};
+
+#[cfg(not(feature = "std"))]
+mod imp {
+    use core::{
+        cell::UnsafeCell,
+        fmt,
+        ops::{Add, AddAssign, Sub, SubAssign},
+        sync::atomic::{AtomicBool, Ordering as AtomicOrdering},
+    };
+    #[cfg(target_arch = "wasm32")]
+    use js_sys::Date;
+
+    type NowFn = fn() -> u128;
+
+    struct ProviderCell {
+        func: UnsafeCell<NowFn>,
+        is_custom: AtomicBool,
+    }
+
+    unsafe impl Sync for ProviderCell {}
+
+    const fn default_now() -> u128 {
+        0
+    }
+
+    impl ProviderCell {
+        const fn new() -> Self {
+            Self {
+                func: UnsafeCell::new(default_now),
+                is_custom: AtomicBool::new(false),
+            }
+        }
+    }
+
+    static TIME_PROVIDER: ProviderCell = ProviderCell::new();
+
+    fn now_fn() -> NowFn {
+        unsafe { *TIME_PROVIDER.func.get() }
+    }
+
+    /// Configure the global time provider used by `Instant::now` and `SystemTime::now`.
+    ///
+    /// The provided function is expected to return the number of nanoseconds elapsed since an
+    /// arbitrary monotonic epoch. Consumers running in `no_std` environments should set this hook
+    /// during start-up to integrate with their platform specific timer source.
+    pub fn set_time_provider(provider: NowFn) {
+        unsafe { *TIME_PROVIDER.func.get() = provider };
+        TIME_PROVIDER.is_custom.store(true, AtomicOrdering::Release);
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    fn wasm_now_provider() -> u128 {
+        let millis = Date::now().max(0.0);
+        (millis * 1_000_000.0) as u128
+    }
+
+    fn load_ticks() -> u128 {
+        #[cfg(target_arch = "wasm32")]
+        {
+            if !TIME_PROVIDER.is_custom.load(AtomicOrdering::Acquire) {
+                set_time_provider(wasm_now_provider);
+            }
+        }
+
+        (now_fn())()
+    }
+
+    #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Default)]
+    pub struct Duration {
+        nanos: u128,
+    }
+
+    impl Duration {
+        pub const ZERO: Self = Self { nanos: 0 };
+
+        pub const fn from_nanos(nanos: u64) -> Self {
+            Self {
+                nanos: nanos as u128,
+            }
+        }
+
+        pub fn from_micros(micros: u64) -> Self {
+            Self::from_total_nanos(
+                (micros as u128)
+                    .checked_mul(1_000)
+                    .expect("overflow in Duration::from_micros"),
+            )
+        }
+
+        pub fn from_millis(millis: u64) -> Self {
+            Self::from_total_nanos(
+                (millis as u128)
+                    .checked_mul(1_000_000)
+                    .expect("overflow in Duration::from_millis"),
+            )
+        }
+
+        pub fn from_secs(secs: u64) -> Self {
+            Self::from_total_nanos(
+                (secs as u128)
+                    .checked_mul(1_000_000_000)
+                    .expect("overflow in Duration::from_secs"),
+            )
+        }
+
+        pub fn as_secs(&self) -> u64 {
+            (self.nanos / 1_000_000_000).min(u64::MAX as u128) as u64
+        }
+
+        pub fn as_secs_f64(&self) -> f64 {
+            self.nanos as f64 / 1_000_000_000.0
+        }
+
+        pub fn as_millis(&self) -> u128 {
+            self.nanos / 1_000_000
+        }
+
+        pub fn as_micros(&self) -> u128 {
+            self.nanos / 1_000
+        }
+
+        pub fn as_nanos(&self) -> u128 {
+            self.nanos
+        }
+
+        pub fn checked_add(self, rhs: Self) -> Option<Self> {
+            self.nanos
+                .checked_add(rhs.nanos)
+                .map(Self::from_total_nanos)
+        }
+
+        pub fn checked_sub(self, rhs: Self) -> Option<Self> {
+            self.nanos
+                .checked_sub(rhs.nanos)
+                .map(Self::from_total_nanos)
+        }
+
+        const fn from_total_nanos(nanos: u128) -> Self {
+            Self { nanos }
+        }
+    }
+
+    impl fmt::Debug for Duration {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.debug_struct("Duration")
+                .field("secs", &self.as_secs())
+                .field("nanos", &(self.nanos % 1_000_000_000))
+                .finish()
+        }
+    }
+
+    impl Add for Duration {
+        type Output = Self;
+
+        fn add(self, rhs: Self) -> Self::Output {
+            self.checked_add(rhs)
+                .expect("overflow when adding Durations")
+        }
+    }
+
+    impl Sub for Duration {
+        type Output = Self;
+
+        fn sub(self, rhs: Self) -> Self::Output {
+            self.checked_sub(rhs)
+                .expect("overflow when subtracting Durations")
+        }
+    }
+
+    impl AddAssign for Duration {
+        fn add_assign(&mut self, rhs: Self) {
+            *self = (*self) + rhs;
+        }
+    }
+
+    impl SubAssign for Duration {
+        fn sub_assign(&mut self, rhs: Self) {
+            *self = (*self) - rhs;
+        }
+    }
+
+    #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Default)]
+    pub struct Instant {
+        nanos_since_epoch: u128,
+    }
+
+    impl Instant {
+        pub fn now() -> Self {
+            Self {
+                nanos_since_epoch: load_ticks(),
+            }
+        }
+
+        pub fn checked_duration_since(&self, earlier: Self) -> Option<Duration> {
+            self.nanos_since_epoch
+                .checked_sub(earlier.nanos_since_epoch)
+                .map(Duration::from_total_nanos)
+        }
+
+        pub fn duration_since(&self, earlier: Self) -> Duration {
+            self.checked_duration_since(earlier)
+                .expect("earlier instant is later than Self")
+        }
+
+        pub fn elapsed(&self) -> Duration {
+            Self::now().duration_since(*self)
+        }
+
+        pub fn checked_add(&self, duration: Duration) -> Option<Self> {
+            self.nanos_since_epoch
+                .checked_add(duration.nanos)
+                .map(|nanos| Self {
+                    nanos_since_epoch: nanos,
+                })
+        }
+
+        pub fn checked_sub(&self, duration: Duration) -> Option<Self> {
+            self.nanos_since_epoch
+                .checked_sub(duration.nanos)
+                .map(|nanos| Self {
+                    nanos_since_epoch: nanos,
+                })
+        }
+    }
+
+    impl fmt::Debug for Instant {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.debug_tuple("Instant")
+                .field(&self.nanos_since_epoch)
+                .finish()
+        }
+    }
+
+    impl Add<Duration> for Instant {
+        type Output = Self;
+
+        fn add(self, rhs: Duration) -> Self::Output {
+            self.checked_add(rhs)
+                .expect("overflow when adding Duration to Instant")
+        }
+    }
+
+    impl Sub<Duration> for Instant {
+        type Output = Self;
+
+        fn sub(self, rhs: Duration) -> Self::Output {
+            self.checked_sub(rhs)
+                .expect("overflow when subtracting Duration from Instant")
+        }
+    }
+
+    impl Sub for Instant {
+        type Output = Duration;
+
+        fn sub(self, rhs: Self) -> Self::Output {
+            self.duration_since(rhs)
+        }
+    }
+
+    #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Default)]
+    pub struct SystemTime {
+        nanos_since_unix_epoch: u128,
+    }
+
+    pub const UNIX_EPOCH: SystemTime = SystemTime {
+        nanos_since_unix_epoch: 0,
+    };
+
+    impl SystemTime {
+        pub fn now() -> Self {
+            Self {
+                nanos_since_unix_epoch: load_ticks(),
+            }
+        }
+
+        pub fn duration_since(&self, earlier: Self) -> Result<Duration, SystemTimeError> {
+            match self
+                .nanos_since_unix_epoch
+                .checked_sub(earlier.nanos_since_unix_epoch)
+            {
+                Some(diff) => Ok(Duration::from_total_nanos(diff)),
+                None => Err(SystemTimeError(Duration::from_total_nanos(
+                    earlier
+                        .nanos_since_unix_epoch
+                        .checked_sub(self.nanos_since_unix_epoch)
+                        .unwrap(),
+                ))),
+            }
+        }
+
+        pub fn elapsed(&self) -> Result<Duration, SystemTimeError> {
+            self.duration_since(UNIX_EPOCH)
+        }
+
+        pub fn checked_add(&self, duration: Duration) -> Option<Self> {
+            self.nanos_since_unix_epoch
+                .checked_add(duration.nanos)
+                .map(|nanos| Self {
+                    nanos_since_unix_epoch: nanos,
+                })
+        }
+
+        pub fn checked_sub(&self, duration: Duration) -> Option<Self> {
+            self.nanos_since_unix_epoch
+                .checked_sub(duration.nanos)
+                .map(|nanos| Self {
+                    nanos_since_unix_epoch: nanos,
+                })
+        }
+    }
+
+    impl fmt::Debug for SystemTime {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.debug_tuple("SystemTime")
+                .field(&self.nanos_since_unix_epoch)
+                .finish()
+        }
+    }
+
+    #[derive(Copy, Clone, Eq, PartialEq)]
+    pub struct SystemTimeError(Duration);
+
+    impl SystemTimeError {
+        pub fn duration(&self) -> Duration {
+            self.0
+        }
+    }
+
+    impl fmt::Debug for SystemTimeError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.debug_tuple("SystemTimeError").field(&self.0).finish()
+        }
+    }
+
+    impl fmt::Display for SystemTimeError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "second time provided was later than self")
+        }
+    }
+
+    #[cfg(feature = "std")]
+    impl std::error::Error for SystemTimeError {}
+}
+
+#[cfg(not(feature = "std"))]
+pub use imp::{set_time_provider, Duration, Instant, SystemTime, SystemTimeError, UNIX_EPOCH};

--- a/crates/steel-core/src/values/closed.rs
+++ b/crates/steel-core/src/values/closed.rs
@@ -1032,7 +1032,7 @@ impl<T: HeapAble + Sync + Send + 'static> FreeList<T> {
     }
 
     fn grow_by(&mut self, amount: usize) {
-        // let now = std::time::Instant::now();
+        // let now = crate::time::Instant::now();
         // Can probably make this a lot bigger
         let current = self.elements.len().max(amount);
 
@@ -1042,7 +1042,7 @@ impl<T: HeapAble + Sync + Send + 'static> FreeList<T> {
 
         log::debug!(target: "gc", "Time to extend the heap vec");
 
-        // let now = std::time::Instant::now();
+        // let now = crate::time::Instant::now();
 
         // Can we pre allocate this somewhere else? Incrementally allocate the values?
         // So basically we can have the elements be allocated vs not, and just have them
@@ -1275,7 +1275,7 @@ impl<T: HeapAble + 'static> FreeList<T> {
     }
 
     fn grow(&mut self) {
-        // let now = std::time::Instant::now();
+        // let now = crate::time::Instant::now();
         // Can probably make this a lot bigger
         let current = self.elements.len().max(Self::EXTEND_CHUNK);
 
@@ -1285,7 +1285,7 @@ impl<T: HeapAble + 'static> FreeList<T> {
 
         log::debug!(target: "gc", "Time to extend the heap vec");
 
-        // let now = std::time::Instant::now();
+        // let now = crate::time::Instant::now();
 
         // Can we pre allocate this somewhere else? Incrementally allocate the values?
         // So basically we can have the elements be allocated vs not, and just have them
@@ -1684,7 +1684,7 @@ impl Heap {
         }
 
         if self.memory_free_list.percent_full() > 0.95 || force {
-            // let now = std::time::Instant::now();
+            // let now = crate::time::Instant::now();
             // Attempt a weak collection
             log::debug!(target: "gc", "SteelVal gc invocation");
             self.memory_free_list.weak_collection();
@@ -1781,7 +1781,7 @@ impl Heap {
         }
 
         if self.vector_free_list.percent_full() > 0.95 || force {
-            // let now = std::time::Instant::now();
+            // let now = crate::time::Instant::now();
             // Attempt a weak collection
             log::debug!(target: "gc", "Vec<SteelVal> gc invocation");
             self.vector_free_list.weak_collection();
@@ -1856,7 +1856,7 @@ impl Heap {
         }
 
         if self.vector_free_list.percent_full() > 0.95 {
-            // let now = std::time::Instant::now();
+            // let now = crate::time::Instant::now();
             // Attempt a weak collection
             log::debug!(target: "gc", "Vec<SteelVal> gc invocation");
             self.vector_free_list.weak_collection();
@@ -1924,7 +1924,7 @@ impl Heap {
         );
 
         #[cfg(feature = "profiling")]
-        let now = std::time::Instant::now();
+        let now = crate::time::Instant::now();
 
         #[cfg(feature = "sync")]
         {
@@ -1960,7 +1960,7 @@ impl Heap {
         log::debug!(target: "gc", "Marking the heap");
 
         #[cfg(feature = "profiling")]
-        let now = std::time::Instant::now();
+        let now = crate::time::Instant::now();
 
         let mut context = MarkAndSweepContext {
             queue: &mut self.mark_and_sweep_queue,
@@ -2081,7 +2081,7 @@ impl ParallelMarker {
                 // This... might be too big?
                 let mut local_queue = Vec::with_capacity(4096);
                 for _ in receiver {
-                    let now = std::time::Instant::now();
+                    let now = crate::time::Instant::now();
 
                     let mut context = MarkAndSweepContextRefQueue {
                         queue: &cloned_queue,


### PR DESCRIPTION
- Introduce time.rs to abstract Instant, Duration, SystemTime, and UNIX_EPOCH for std vs no_std builds.
- Swap all steel-core call sites to crate::time::* so std behavior remains unchanged while no_std can plug in a custom time provider.
- Make chrono optional but enabled via the std feature to preserve default behavior, and add js-sys for wasm time support.

Changes:
- Added steel-core::time module and exported from lib.rs.
- Replaced std::time::* usages across compiler, VM, parser, primitives, values with crate::time::*.
- Cargo.toml: chrono is optional + enabled by std; added wasm js-sys.

Tests:
- cargo test --all -> ok