### PR TITLE
forge: don't try to create a string with negative length

### DIFF
--- a/crates/forge/installer/main.scm
+++ b/crates/forge/installer/main.scm
@@ -3,10 +3,18 @@
 (require "download.scm")
 
 (define (list-packages index)
+  ; width of the "Package" string
+  (define package-width (string-length "Package"))
+  ; maximum length of the names of the packages,
+  ; clamped to the `package-width`
   (define package-name-width
-    (apply max
-           (map (lambda (package) (string-length (symbol->string (hash-ref package 'package-name))))
-                (hash-values->list index))))
+    (if (hash-empty? index)
+        package-width
+        (max package-width
+             (apply max
+                    (map (lambda (package)
+                           (string-length (symbol->string (hash-ref package 'package-name))))
+                         (hash-values->list index))))))
 
   (define version-width (string-length "Version"))
 
@@ -14,7 +22,7 @@
   (displayln)
 
   (display "Package")
-  (display (make-string (- package-name-width (string-length "Package")) #\SPACE))
+  (display (make-string (- package-name-width package-width) #\SPACE))
   (display "  ")
   (displayln "Version")
 


### PR DESCRIPTION
i deleted all the packages for testing and then ran into two separate bugs:

- the `(apply max ...)` doesn't work if the hash map is empty as `max` will throw an arity error with no arguments.
- if all packages are shorter than the `"Packages"` string, it will try to allocate a string with a length of `-1`, which obviously doesn't work.

this fixes both of these isssues.