### PR TITLE
add aliases to bytevector procedures for r7rs compat

### DIFF
--- a/crates/steel-core/src/primitives/bytevectors.rs
+++ b/crates/steel-core/src/primitives/bytevectors.rs
@@ -67,7 +67,7 @@ pub fn bytevector(args: &[SteelVal]) -> Result<SteelVal> {
 /// ```scheme
 /// (bytes 65 112 112 108 101)
 /// ```
-#[steel_derive::native(name = "bytes", arity = "AtLeast(0)")]
+#[steel_derive::native(name = "bytes", alias = "bytevector", arity = "AtLeast(0)")]
 pub fn bytes(args: &[SteelVal]) -> Result<SteelVal> {
     args.iter()
         .map(|x| u8::from_steelval(x))
@@ -83,7 +83,7 @@ pub fn bytes(args: &[SteelVal]) -> Result<SteelVal> {
 /// (bytes? (bytes 0 1 2)) ;; => #t
 /// (bytes? (list 10 20 30)) ;; => #f
 /// ```
-#[steel_derive::function(name = "bytes?")]
+#[steel_derive::function(name = "bytes?", alias = "bytevector?")]
 pub fn is_bytes(arg: &SteelVal) -> bool {
     matches!(arg, SteelVal::ByteVector(_))
 }
@@ -101,10 +101,10 @@ pub fn is_bytes(arg: &SteelVal) -> bool {
 /// ```scheme
 /// (define vec (bytes 1 2 3 4 5))
 ///
-/// (bytevector-copy vec) ;; => (bytes 1 2 3 4 5)
-/// (bytevector-copy vec 1 3) ;; => (bytes 2 3)
+/// (bytes-copy vec) ;; => (bytes 1 2 3 4 5)
+/// (bytes-copy vec 1 3) ;; => (bytes 2 3)
 /// ```
-#[steel_derive::function(name = "bytevector-copy")]
+#[steel_derive::function(name = "bytes-copy", alias = "bytevector-copy")]
 pub fn bytevector_copy_new(
     bytevector: &SteelByteVector,
     mut rest: RestArgsIter<'_, isize>,
@@ -153,7 +153,7 @@ pub fn bytevector_copy_new(
 /// ```scheme
 /// (make-bytes 6 42) ;; => (bytes 42 42 42 42 42)
 /// ```
-#[function(name = "make-bytes")]
+#[function(name = "make-bytes", alias = "make-bytevector")]
 pub fn make_bytes(k: usize, mut c: RestArgsIter<'_, isize>) -> Result<SteelVal> {
     let default = c.next();
 
@@ -203,7 +203,7 @@ pub fn is_byte(value: &SteelVal) -> bool {
 /// ```scheme
 /// (bytes-length (bytes 1 2 3 4 5)) ;; => 5
 /// ```
-#[function(name = "bytes-length")]
+#[function(name = "bytes-length", alias = "bytevector-length")]
 pub fn bytes_length(value: &SteelByteVector) -> usize {
     value.vec.read().len()
 }
@@ -221,7 +221,7 @@ pub fn bytes_length(value: &SteelByteVector) -> usize {
 /// (bytes-ref (bytes 0 1 2 3 4 5) 3) ;; => 4
 /// (bytes-ref (bytes) 10) ;; error
 /// ```
-#[function(name = "bytes-ref")]
+#[function(name = "bytes-ref", alias = "bytevector-u8-ref")]
 pub fn bytes_ref(value: &SteelByteVector, index: usize) -> Result<SteelVal> {
     let guard = value.vec.read();
     guard
@@ -247,7 +247,7 @@ pub fn bytes_ref(value: &SteelByteVector, index: usize) -> Result<SteelVal> {
 /// (bytes-set! my-bytes 0 100)
 /// (bytes-ref my-bytes 0) ;; => 100
 /// ```
-#[function(name = "bytes-set!")]
+#[function(name = "bytes-set!", alias = "bytevector-u8-set!")]
 pub fn bytes_set(value: &mut SteelByteVector, index: usize, byte: u8) -> Result<SteelVal> {
     let mut guard = value.vec.write();
 
@@ -313,7 +313,7 @@ pub fn list_to_bytes(value: Vec<u8>) -> Result<SteelVal> {
 ///
 /// (bytes-append #u8(0) #u8(1) #u8() #u8(2)) ;; => #u8(#x00 #x01 #x02)
 /// ```
-#[function(name = "bytes-append")]
+#[function(name = "bytes-append", alias = "bytevector-append")]
 pub fn bytes_append(mut rest: RestArgsIter<'_, &SteelByteVector>) -> Result<SteelVal> {
     let mut vector = vec![];
 

--- a/crates/steel-core/src/primitives/ports.rs
+++ b/crates/steel-core/src/primitives/ports.rs
@@ -64,7 +64,6 @@ pub fn port_module() -> BuiltInModule {
         .register_native_fn_definition(PEEK_BYTE_DEFINITION)
         .register_native_fn_definition(READ_BYTES_DEFINITION)
         .register_native_fn_definition(READ_BYTES_INTO_DEFINITION)
-        .register_native_fn_definition(READ_BYTES_INTO_BUF_DEFINITION)
         .register_native_fn_definition(WOULD_BLOCK_OBJECTP_DEFINITION)
         .register_native_fn_definition(WOULD_BLOCK_OBJECT_DEFINITION);
     module
@@ -110,7 +109,6 @@ pub fn port_module_without_filesystem() -> BuiltInModule {
         .register_native_fn_definition(PEEK_BYTE_DEFINITION)
         .register_native_fn_definition(READ_BYTES_DEFINITION)
         .register_native_fn_definition(READ_BYTES_INTO_DEFINITION)
-        .register_native_fn_definition(READ_BYTES_INTO_BUF_DEFINITION)
         .register_native_fn_definition(WOULD_BLOCK_OBJECTP_DEFINITION)
         .register_native_fn_definition(WOULD_BLOCK_OBJECT_DEFINITION)
         .register_native_fn_definition(IS_STRING_INPUT_DEFINITION)
@@ -673,33 +671,6 @@ pub fn read_bytes(amt: usize, port: &SteelPort) -> Result<SteelVal> {
             }
         }
         crate::values::port::MaybeBlocking::WouldBlock => Ok(would_block_object()),
-    }
-}
-
-/// Reads bytes from an input port into a given buffer.
-///
-/// (read-bytes-into-buf buf amt [port]) -> int?
-///
-/// * buf : bytes?
-/// * amt : (and positive? int?)
-/// * port : input-port? = (current-input-port)
-#[function(name = "#%read-bytes-into-buf")]
-pub fn read_bytes_into_buf(
-    buf: &SteelByteVector,
-    amt: usize,
-    port: &SteelPort,
-) -> Result<SteelVal> {
-    let mut guard = buf.vec.write();
-
-    if guard.len() < amt {
-        stop!(ContractViolation => "read-bytes-into-buf expects a buffer with the capacity to fill the buffer with the specified amount");
-    }
-
-    let res = port.read_bytes_into_buf(&mut guard)?;
-
-    match res {
-        crate::values::port::MaybeBlocking::Nonblocking(amt) => Ok(SteelVal::IntV(amt as _)),
-        crate::values::port::MaybeBlocking::WouldBlock => Ok(SteelVal::Void),
     }
 }
 

--- a/crates/steel-core/src/primitives/ports.rs
+++ b/crates/steel-core/src/primitives/ports.rs
@@ -63,6 +63,7 @@ pub fn port_module() -> BuiltInModule {
         .register_native_fn_definition(WRITE_BYTES_DEFINITION)
         .register_native_fn_definition(PEEK_BYTE_DEFINITION)
         .register_native_fn_definition(READ_BYTES_DEFINITION)
+        .register_native_fn_definition(READ_BYTES_INTO_DEFINITION)
         .register_native_fn_definition(READ_BYTES_INTO_BUF_DEFINITION)
         .register_native_fn_definition(WOULD_BLOCK_OBJECTP_DEFINITION)
         .register_native_fn_definition(WOULD_BLOCK_OBJECT_DEFINITION);
@@ -108,6 +109,7 @@ pub fn port_module_without_filesystem() -> BuiltInModule {
         .register_native_fn_definition(WRITE_BYTES_DEFINITION)
         .register_native_fn_definition(PEEK_BYTE_DEFINITION)
         .register_native_fn_definition(READ_BYTES_DEFINITION)
+        .register_native_fn_definition(READ_BYTES_INTO_DEFINITION)
         .register_native_fn_definition(READ_BYTES_INTO_BUF_DEFINITION)
         .register_native_fn_definition(WOULD_BLOCK_OBJECTP_DEFINITION)
         .register_native_fn_definition(WOULD_BLOCK_OBJECT_DEFINITION)
@@ -696,6 +698,26 @@ pub fn read_bytes_into_buf(
     let res = port.read_bytes_into_buf(&mut guard)?;
 
     match res {
+        crate::values::port::MaybeBlocking::Nonblocking(amt) => Ok(SteelVal::IntV(amt as _)),
+        crate::values::port::MaybeBlocking::WouldBlock => Ok(SteelVal::Void),
+    }
+}
+
+#[function(name = "#%read-bytes!")]
+pub fn read_bytes_into(
+    buf: &SteelByteVector,
+    port: &SteelPort,
+    start: usize,
+    end: usize,
+) -> Result<SteelVal> {
+    let mut guard = buf.vec.write();
+    let Some(slice) = guard.get_mut(start..end) else {
+        stop!(ContractViolation => "start and end indices are not valid for the provided buffer");
+    };
+
+    let res = port.read_bytes_into_buf(slice)?;
+    match res {
+        crate::values::port::MaybeBlocking::Nonblocking(0) => Ok(eof_object()),
         crate::values::port::MaybeBlocking::Nonblocking(amt) => Ok(SteelVal::IntV(amt as _)),
         crate::values::port::MaybeBlocking::WouldBlock => Ok(SteelVal::Void),
     }

--- a/crates/steel-core/src/scheme/modules/ports.scm
+++ b/crates/steel-core/src/scheme/modules/ports.scm
@@ -13,6 +13,8 @@
          read-bytes
          read-bytevector
          read-bytes-into-buf
+         read-bytes!
+         read-bytevector!
          write-byte
          write-u8
          write-bytes
@@ -128,6 +130,26 @@
   (case-lambda
     [(buf amt) (#%read-bytes-into-buf buf amt (current-input-port))]
     [(buf amt port) (#%read-bytes-into-buf buf amt port)]))
+
+;;@doc
+;; Reads *end* - *start* bytes from an input port into a given buffer.
+;;
+;; (read-bytes! buf [port] [start] [end])
+;;
+;; * buf : bytes?
+;; * port : input-port? = (current-input-port)
+;; * start : (and positive? int?) = 0
+;; * end : (and positive? int?) = (bytes-length buf)
+(define read-bytes!
+  (case-lambda
+    [(buf) (#%read-bytes! buf (current-input-port) 0 (bytes-length buf))]
+    [(buf port) (#%read-bytes! buf port 0 (bytes-length buf))]
+    [(buf port start) (#%read-bytes! buf port start (bytes-length buf))]
+    [(buf port start end) (#%read-bytes! buf port start end)]))
+
+;;@doc
+;; Alias of `read-bytes!`.
+(define read-bytevector! read-bytes!)
 
 ;;@doc
 ;; Writes a single byte to an output port.

--- a/crates/steel-core/src/scheme/modules/ports.scm
+++ b/crates/steel-core/src/scheme/modules/ports.scm
@@ -119,7 +119,7 @@
 (define read-bytevector read-bytes)
 
 ;;@doc
-;; Reads bytes from an input port into a given buffer.
+;; Reads *amt* bytes from an input port into a given buffer.
 ;;
 ;; (read-bytes-into-buf buf amt [port]) -> int?
 ;;
@@ -128,8 +128,8 @@
 ;; * port : input-port? = (current-input-port)
 (define read-bytes-into-buf
   (case-lambda
-    [(buf amt) (#%read-bytes-into-buf buf amt (current-input-port))]
-    [(buf amt port) (#%read-bytes-into-buf buf amt port)]))
+    [(buf amt) (#%read-bytes! buf (current-input-port) 0 amt)]
+    [(buf amt port) (#%read-bytes! buf port 0 amt)]))
 
 ;;@doc
 ;; Reads *end* - *start* bytes from an input port into a given buffer.

--- a/crates/steel-core/src/tests/success/ports.scm
+++ b/crates/steel-core/src/tests/success/ports.scm
@@ -56,3 +56,21 @@
     (assert-equal! "one" (read-line))
     (assert! (eof-object? (read-char)))
     (assert! (eof-object? (read-byte)))))
+
+(let ([input-port (open-input-string "one two")]
+      [buf (make-bytes 7)])
+  (assert-equal! (read-bytes-into-buf buf 3 input-port) 3)
+  (assert-equal! buf (string->bytes "one\0\0\0\0"))
+  (assert-equal! (peek-char input-port) #\space)
+  (assert-equal! (read-bytes-into-buf buf 7 input-port) 4)
+  (assert-equal! buf (string->bytes " two\0\0\0"))
+  (assert! (eof-object? (peek-char input-port))))
+
+(let ([input-port (open-input-string "one two")]
+      [buf (make-bytes 7)])
+  (assert-equal! (read-bytes! buf input-port 2 5) 3)
+  (assert-equal! buf (string->utf8 "\0\0one\0\0"))
+  (assert-equal! (peek-char input-port) #\space)
+  (assert-equal! (read-bytes! buf input-port) 4)
+  (assert-equal! buf (string->utf8 " twoe\0\0"))
+  (assert! (eof-object? (peek-char input-port))))

--- a/docs/src/builtins/steel_base.md
+++ b/docs/src/builtins/steel_base.md
@@ -366,6 +366,23 @@ Append multiple byte vectors into a new bytevector.
 
 (bytes-append #u8(0) #u8(1) #u8() #u8(2)) ;; => #u8(#x00 #x01 #x02)
 ```
+### **bytes-copy**
+Creates a copy of a bytevector.
+
+(bytevector-copy vector [start end]) -> bytes?
+
+* vector : bytes?
+* start: int? = 0
+* end: int? = (bytes-length vector)
+
+#### Examples
+
+```scheme
+(define vec (bytes 1 2 3 4 5))
+
+(bytes-copy vec) ;; => (bytes 1 2 3 4 5)
+(bytes-copy vec 1 3) ;; => (bytes 2 3)
+```
 ### **bytes-length**
 Returns the length of the given byte vector
 
@@ -425,23 +442,18 @@ integer range from 0 - 255 (inclusive)
 ```scheme
 (bytevector 65 112 112 108 101)
 ```
+### **bytevector-append**
+Alias of `bytes-append`.
 ### **bytevector-copy**
-Creates a copy of a bytevector.
-
-(bytevector-copy vector [start end]) -> bytes?
-
-* vector : bytes?
-* start: int? = 0
-* end: int? = (bytes-length vector)
-
-#### Examples
-
-```scheme
-(define vec (bytes 1 2 3 4 5))
-
-(bytevector-copy vec) ;; => (bytes 1 2 3 4 5)
-(bytevector-copy vec 1 3) ;; => (bytes 2 3)
-```
+Alias of `bytes-copy`.
+### **bytevector-length**
+Alias of `bytes-length`.
+### **bytevector-u8-ref**
+Alias of `bytes-ref`.
+### **bytevector-u8-set!**
+Alias of `bytes-set!`.
+### **bytevector?**
+Alias of `bytes?`.
 ### **canonicalize-path**
 Returns canonical path with all components normalized.
 
@@ -2087,6 +2099,8 @@ Creates a bytevector given a length and a default value.
 ```scheme
 (make-bytes 6 42) ;; => (bytes 42 42 42 42 42)
 ```
+### **make-bytevector**
+Alias of `make-bytes`.
 ### **make-polar**
 Make a complex number out of a magnitude `r` and an angle `θ`, so that the result is `r * (cos θ + i sin θ)`
 

--- a/docs/src/builtins/steel_bytevectors.md
+++ b/docs/src/builtins/steel_bytevectors.md
@@ -54,6 +54,23 @@ Append multiple byte vectors into a new bytevector.
 
 (bytes-append #u8(0) #u8(1) #u8() #u8(2)) ;; => #u8(#x00 #x01 #x02)
 ```
+### **bytes-copy**
+Creates a copy of a bytevector.
+
+(bytevector-copy vector [start end]) -> bytes?
+
+* vector : bytes?
+* start: int? = 0
+* end: int? = (bytes-length vector)
+
+#### Examples
+
+```scheme
+(define vec (bytes 1 2 3 4 5))
+
+(bytes-copy vec) ;; => (bytes 1 2 3 4 5)
+(bytes-copy vec 1 3) ;; => (bytes 2 3)
+```
 ### **bytes-length**
 Returns the length of the given byte vector
 
@@ -113,23 +130,18 @@ integer range from 0 - 255 (inclusive)
 ```scheme
 (bytevector 65 112 112 108 101)
 ```
+### **bytevector-append**
+Alias of `bytes-append`.
 ### **bytevector-copy**
-Creates a copy of a bytevector.
-
-(bytevector-copy vector [start end]) -> bytes?
-
-* vector : bytes?
-* start: int? = 0
-* end: int? = (bytes-length vector)
-
-#### Examples
-
-```scheme
-(define vec (bytes 1 2 3 4 5))
-
-(bytevector-copy vec) ;; => (bytes 1 2 3 4 5)
-(bytevector-copy vec 1 3) ;; => (bytes 2 3)
-```
+Alias of `bytes-copy`.
+### **bytevector-length**
+Alias of `bytes-length`.
+### **bytevector-u8-ref**
+Alias of `bytes-ref`.
+### **bytevector-u8-set!**
+Alias of `bytes-set!`.
+### **bytevector?**
+Alias of `bytes?`.
 ### **list->bytes**
 Converts the list of bytes to the equivalent bytevector representation.
 The list must contain _only_ values which satisfy the `byte?` predicate,
@@ -151,6 +163,8 @@ Creates a bytevector given a length and a default value.
 ```scheme
 (make-bytes 6 42) ;; => (bytes 42 42 42 42 42)
 ```
+### **make-bytevector**
+Alias of `make-bytes`.
 ### **utf8->string**
 Alias of `bytes->string/utf8`.
 ### **bytes-clear!**

--- a/docs/src/stdlib/private_steel_ports.md
+++ b/docs/src/stdlib/private_steel_ports.md
@@ -70,8 +70,17 @@ Reads bytes from an input port.
 
 * amt : (and positive? int?)
 * port : input-port? = (current-input-port)
+### **read-bytes!**
+Reads *end* - *start* bytes from an input port into a given buffer.
+
+(read-bytes! buf [port] [start] [end])
+
+* buf : bytes?
+* port : input-port? = (current-input-port)
+* start : (and positive? int?) = 0
+* end : (and positive? int?) = (bytes-length buf)
 ### **read-bytes-into-buf**
-Reads bytes from an input port into a given buffer.
+Reads *amt* bytes from an input port into a given buffer.
 
 (read-bytes-into-buf buf amt [port]) -> int?
 
@@ -80,6 +89,8 @@ Reads bytes from an input port into a given buffer.
 * port : input-port? = (current-input-port)
 ### **read-bytevector**
 Alias of `read-bytes`.
+### **read-bytevector!**
+Alias of `read-bytes!`.
 ### **read-char**
 Reads the next character from an input port.
 


### PR DESCRIPTION
and also add an alias for `bytes-copy` for `bytevector-copy` for consistency.

additionally implement `bytes-read!` (with a `bytevector-read!` alias) and actually respect the parameter for `read-bytes-into-buf` by just implenting that via the `bytes-read!` procedure.