### PR TITLE
Add From<Vec<u8>> and FromFFIArg<Vec<u8>> for FFIValue ByteVector

### DIFF
--- a/crates/steel-core/src/steel_vm/ffi.rs
+++ b/crates/steel-core/src/steel_vm/ffi.rs
@@ -388,6 +388,16 @@ impl<'a> FromFFIArg<'a> for RVec<u8> {
     }
 }
 
+impl<'a> FromFFIArg<'a> for Vec<u8> {
+    fn from_ffi_arg(val: FFIArg<'a>) -> RResult<Self, RBoxError> {
+        if let FFIArg::ByteVector(b) = val {
+            RResult::ROk(b.into())
+        } else {
+            conversion_error!(bytevector, val)
+        }
+    }
+}
+
 impl<'a, T: Custom + Clone + 'static> FromFFIArg<'a> for T {
     fn from_ffi_arg(val: FFIArg<'a>) -> RResult<Self, RBoxError> {
         let lifted = unsafe { core::mem::transmute::<FFIArg<'a>, FFIArg<'static>>(val) };
@@ -425,6 +435,18 @@ impl From<usize> for FFIValue {
 impl From<String> for FFIValue {
     fn from(value: String) -> Self {
         FFIValue::StringV(RString::from(value))
+    }
+}
+
+impl From<Vec<u8>> for FFIValue {
+    fn from(value: Vec<u8>) -> Self {
+        FFIValue::ByteVector(RVec::from(value))
+    }
+}
+
+impl From<RVec<u8>> for FFIValue {
+    fn from(value: RVec<u8>) -> Self {
+        FFIValue::ByteVector(value)
     }
 }
 


### PR DESCRIPTION
Dylib FFI functions can currently *accept* byte vectors as `RVec<u8>`, but there is no
way to *return* one as a Steel bytevector: a returned `Vec<u8>` goes through
`IntoFFIVal for Vec<T>` and arrives in Scheme as a list of integers, so `bytes-length`,
`bytes-ref` etc. fail on it.

This adds the two missing ergonomic impls:

- `From<Vec<u8>> for FFIValue` (and `From<RVec<u8>>`) — returned byte buffers become
  proper `FFIValue::ByteVector`s
- `FromFFIArg<'a> for Vec<u8>` — owned-`Vec` arguments work symmetrically with the
  existing `RVec<u8>` support

Use case: a Helix plugin's companion dylib streams animation frames (kitty graphics
payloads) to the Steel side as bytevectors. Without this, binary transport needs
base64 strings or per-byte list conversion.

One possible concern: `From<Vec<u8>> for FFIValue` makes `Vec<u8>` returns bytevectors
while other `Vec<T>` returns stay lists — an asymmetry, but the same one Rust itself
has (`Vec<u8>` is the de-facto byte-buffer type), and it can't break existing code
because `Vec<u8>` previously satisfied only the list path via `IntoFFIVal`, which the
blanket `impl<T: Into<FFIValue>> IntoFFIVal for T` now shadows for this one type.
**Reviewer should confirm Matt is comfortable with that override** — a returned
`Vec<u8>` that some existing plugin expected as a list would change type. If that's a
worry, the alternative is a `ByteVec` newtype instead; happy to rework.

**Testing:** builds + existing steel-core tests pass on the branch; consumer
(libnothelix) exercises both directions in its animation test suite (316 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
