### PR TITLE
language-server: don't panic when the lsp home directory is read-only

### DIFF
--- a/crates/steel-language-server/src/backend.rs
+++ b/crates/steel-language-server/src/backend.rs
@@ -62,7 +62,11 @@ pub fn lsp_home() -> PathBuf {
     home_directory.push("lsp");
 
     if !home_directory.exists() {
-        std::fs::create_dir_all(&home_directory).expect("Unable to create the lsp home directory");
+        // Best effort: on a read-only filesystem (e.g. a Nix store default
+        // `STEEL_HOME`) we cannot create this directory. The language server
+        // does not require it to exist to function, so a failure here should
+        // not abort startup.
+        let _ = std::fs::create_dir_all(&home_directory);
     }
 
     home_directory


### PR DESCRIPTION
Fixes #670. On NixOS the default `STEEL_HOME` points into the read-only Nix store, so `lsp_home()` aborts at startup when `create_dir_all` fails. Both call sites already tolerate the directory being absent (`main.rs` hands it to the module resolver and `backend.rs` guards the read with `if let Ok(read_dir(..))`), so this makes the create best-effort instead of a hard `expect`.