### PR TITLE
Make serialized programs runnable in a fresh engine (constant map merge + faithful round trip)

### DIFF
--- a/crates/steel-core/src/compiler/compiler.rs
+++ b/crates/steel-core/src/compiler/compiler.rs
@@ -577,7 +577,7 @@ impl Compiler {
     pub(crate) fn into_serializable_compiler(self) -> Result<SerializableCompiler> {
         Ok(SerializableCompiler {
             symbol_map: self.symbol_map,
-            constant_map: self.constant_map.into_serializable_map(),
+            constant_map: self.constant_map.into_serializable_map()?,
             macro_env: self.macro_env,
             opt_level: self.opt_level,
             module_manager: self.module_manager,

--- a/crates/steel-core/src/compiler/constants.rs
+++ b/crates/steel-core/src/compiler/constants.rs
@@ -6,24 +6,21 @@ use crate::gc::shared::MutContainer;
 #[cfg(not(feature = "sync"))]
 use crate::gc::shared::ShareableMut;
 
-use crate::gc::{Shared, SharedMut};
-use crate::parser::tryfrom_visitor::TryFromExprKindForSteelVal;
+use crate::gc::{Gc, Shared, SharedMut};
+use crate::rerrs::{ErrorKind, SteelErr};
 use crate::rvals::{
-    into_serializable_value, Result, SerializableSteelVal, SerializationContext, SteelVal,
+    into_serializable_value, Result, SerializableSteelVal, SerializationContext, SteelByteVector,
+    SteelComplex, SteelVal,
 };
-
-use crate::parser::{
-    ast::ExprKind,
-    parser::{ParseError, Parser},
-};
+use crate::values::lists::Pair;
 
 use alloc::sync::Arc;
 
 use arc_swap::ArcSwap;
+use num_bigint::BigInt;
+use num_rational::{BigRational, Rational32};
 use rustc_hash::FxHashMap;
-// TODO add the serializing and deserializing for constants
 use serde::{Deserialize, Serialize};
-use steel_parser::parser::{lower_entire_ast, SourceId};
 
 // Shared constant map - for repeated in memory execution of a program, this is going to share the same
 // underlying representation.
@@ -37,6 +34,108 @@ pub struct ConstantMap {
 
 #[derive(Serialize, Deserialize)]
 pub struct SerializableConstantMap(Vec<u8>);
+
+#[derive(Serialize, Deserialize)]
+enum SerializedConstant {
+    Bool(bool),
+    Int(isize),
+    Float(f64),
+    Rational(Rational32),
+    BigInt(BigInt),
+    BigRational(BigRational),
+    Complex(Box<SerializedConstant>, Box<SerializedConstant>),
+    Char(char),
+    String(String),
+    Symbol(String),
+    List(Vec<SerializedConstant>),
+    Pair(Box<SerializedConstant>, Box<SerializedConstant>),
+    Vector(Vec<SerializedConstant>),
+    ByteVector(Vec<u8>),
+    Void,
+}
+
+impl SerializedConstant {
+    fn from_value(value: &SteelVal) -> Result<SerializedConstant> {
+        match value {
+            SteelVal::BoolV(b) => Ok(SerializedConstant::Bool(*b)),
+            SteelVal::IntV(i) => Ok(SerializedConstant::Int(*i)),
+            SteelVal::NumV(n) => Ok(SerializedConstant::Float(*n)),
+            SteelVal::Rational(r) => Ok(SerializedConstant::Rational(*r)),
+            SteelVal::BigNum(b) => Ok(SerializedConstant::BigInt(b.as_ref().clone())),
+            SteelVal::BigRational(r) => Ok(SerializedConstant::BigRational(r.as_ref().clone())),
+            SteelVal::Complex(c) => Ok(SerializedConstant::Complex(
+                Box::new(SerializedConstant::from_value(&c.re)?),
+                Box::new(SerializedConstant::from_value(&c.im)?),
+            )),
+            SteelVal::CharV(c) => Ok(SerializedConstant::Char(*c)),
+            SteelVal::StringV(s) => Ok(SerializedConstant::String(s.as_str().to_owned())),
+            SteelVal::SymbolV(s) => Ok(SerializedConstant::Symbol(s.as_str().to_owned())),
+            SteelVal::ListV(values) => Ok(SerializedConstant::List(
+                values
+                    .iter()
+                    .map(SerializedConstant::from_value)
+                    .collect::<Result<_>>()?,
+            )),
+            SteelVal::Pair(pair) => Ok(SerializedConstant::Pair(
+                Box::new(SerializedConstant::from_value(&pair.car())?),
+                Box::new(SerializedConstant::from_value(&pair.cdr())?),
+            )),
+            SteelVal::VectorV(values) => Ok(SerializedConstant::Vector(
+                values
+                    .iter()
+                    .map(SerializedConstant::from_value)
+                    .collect::<Result<_>>()?,
+            )),
+            SteelVal::ByteVector(bytes) => {
+                Ok(SerializedConstant::ByteVector(bytes.vec.read().clone()))
+            }
+            SteelVal::Void => Ok(SerializedConstant::Void),
+            unsupported => Err(SteelErr::new(
+                ErrorKind::Generic,
+                format!("constant map serialization does not support value: {unsupported}"),
+            )),
+        }
+    }
+
+    fn into_value(self) -> SteelVal {
+        match self {
+            SerializedConstant::Bool(b) => SteelVal::BoolV(b),
+            SerializedConstant::Int(i) => SteelVal::IntV(i),
+            SerializedConstant::Float(n) => SteelVal::NumV(n),
+            SerializedConstant::Rational(r) => SteelVal::Rational(r),
+            SerializedConstant::BigInt(b) => SteelVal::BigNum(Gc::new(b)),
+            SerializedConstant::BigRational(r) => SteelVal::BigRational(Gc::new(r)),
+            SerializedConstant::Complex(re, im) => {
+                SteelVal::Complex(Gc::new(SteelComplex::new(re.into_value(), im.into_value())))
+            }
+            SerializedConstant::Char(c) => SteelVal::CharV(c),
+            SerializedConstant::String(s) => SteelVal::StringV(s.into()),
+            SerializedConstant::Symbol(s) => SteelVal::SymbolV(s.into()),
+            SerializedConstant::List(values) => SteelVal::ListV(
+                values
+                    .into_iter()
+                    .map(SerializedConstant::into_value)
+                    .collect(),
+            ),
+            SerializedConstant::Pair(car, cdr) => {
+                Pair::cons(car.into_value(), cdr.into_value()).into()
+            }
+            SerializedConstant::Vector(values) => SteelVal::VectorV(
+                Gc::new(
+                    values
+                        .into_iter()
+                        .map(SerializedConstant::into_value)
+                        .collect::<crate::values::Vector<_>>(),
+                )
+                .into(),
+            ),
+            SerializedConstant::ByteVector(bytes) => {
+                SteelVal::ByteVector(SteelByteVector::new(bytes))
+            }
+            SerializedConstant::Void => SteelVal::Void,
+        }
+    }
+}
 
 impl Default for ConstantMap {
     fn default() -> Self {
@@ -64,6 +163,10 @@ impl ConstantMap {
         }
     }
 
+    pub(crate) fn shares_storage_with(&self, other: &ConstantMap) -> bool {
+        Shared::ptr_eq(&self.values, &other.values)
+    }
+
     pub fn flush(&self) {
         let values = self.values.read();
         if values.len() != self.reified_values.load().len() {
@@ -89,8 +192,8 @@ impl ConstantMap {
         }
     }
 
-    pub(crate) fn into_serializable_map(self) -> SerializableConstantMap {
-        SerializableConstantMap(self.to_bytes().unwrap())
+    pub(crate) fn into_serializable_map(self) -> Result<SerializableConstantMap> {
+        Ok(SerializableConstantMap(self.to_bytes()?))
     }
 
     pub fn to_serializable_vec(&self, ctx: &mut SerializationContext) -> Vec<SerializableSteelVal> {
@@ -117,28 +220,20 @@ impl ConstantMap {
         }
     }
 
-    fn to_constant_expr_map(&self) -> Vec<String> {
-        self.values
+    pub fn to_bytes(&self) -> Result<Vec<u8>> {
+        let constants = self
+            .values
             .read()
             .iter()
-            .map(|x| match x {
-                SteelVal::StringV(s) => {
-                    format!("{:?}", s)
-                }
-                SteelVal::CharV(c) => {
-                    format!("#\\{c}")
-                }
-                _ => x.to_string(),
-            })
-            .collect()
-    }
+            .map(SerializedConstant::from_value)
+            .collect::<Result<Vec<_>>>()?;
 
-    pub fn to_bytes(&self) -> Result<Vec<u8>> {
-        let str_vector = self.to_constant_expr_map();
-        // println!("{:?}", str_vector);
-        let result = bincode::serialize(&str_vector);
-
-        Ok(result.unwrap())
+        bincode::serialize(&constants).map_err(|e| {
+            SteelErr::new(
+                ErrorKind::Generic,
+                format!("unable to serialize the constant map: {e}"),
+            )
+        })
     }
 
     pub fn from_serialized(map: SerializableConstantMap) -> Result<Self> {
@@ -146,31 +241,20 @@ impl ConstantMap {
     }
 
     pub fn from_bytes(encoded: &[u8]) -> Result<ConstantMap> {
-        let str_vector: Vec<String> = bincode::deserialize(encoded).unwrap();
+        let constants: Vec<SerializedConstant> = bincode::deserialize(encoded).map_err(|e| {
+            SteelErr::new(
+                ErrorKind::Generic,
+                format!("unable to deserialize the constant map: {e}"),
+            )
+        })?;
 
-        str_vector
-            .into_iter()
-            .map(|x| {
-                // Parse the input
-                let parsed: core::result::Result<Vec<ExprKind>, ParseError> =
-                    Parser::new_flat(&x, SourceId::none()).collect();
-                let mut parsed = parsed?;
-
-                lower_entire_ast(&mut parsed[0])?;
-
-                // println!("{}", &parsed[0]);
-
-                TryFromExprKindForSteelVal::try_from_expr_kind(parsed[0].clone())
-
-                // Ok(SteelVal::try_from(parsed[0].clone()).unwrap())
-            })
-            .collect::<Result<Vec<_>>>()
-            .map(Self::from_vec)
+        Ok(Self::from_vec(
+            constants
+                .into_iter()
+                .map(SerializedConstant::into_value)
+                .collect(),
+        ))
     }
-
-    // pub fn from_bytes(encoded: &[u8]) -> ConstantMap {
-    //     bincode::deserialize(encoded).unwrap()
-    // }
 }
 
 impl ConstantMap {
@@ -277,6 +361,92 @@ impl ConstantMap {
 #[cfg(test)]
 pub mod constant_table_tests {
     use super::*;
+
+    use crate::gc::Gc;
+    use crate::rvals::SteelByteVector;
+    use crate::values::lists::Pair;
+    use num_bigint::BigInt;
+    use num_rational::{BigRational, Rational32};
+
+    fn list_of(values: Vec<SteelVal>) -> SteelVal {
+        SteelVal::ListV(values.into())
+    }
+
+    fn symbol(name: &str) -> SteelVal {
+        SteelVal::SymbolV(name.into())
+    }
+
+    fn representative_constants() -> Vec<SteelVal> {
+        vec![
+            symbol("plain-symbol"),
+            list_of(vec![symbol("quote"), symbol("inner-symbol")]),
+            list_of(vec![
+                symbol("a"),
+                list_of(vec![
+                    symbol("quote"),
+                    list_of(vec![symbol("b"), SteelVal::IntV(1)]),
+                ]),
+                SteelVal::StringV("nested".into()),
+            ]),
+            list_of(vec![
+                symbol("let"),
+                list_of(vec![list_of(vec![symbol("x"), SteelVal::IntV(1)])]),
+                symbol("x"),
+            ]),
+            list_of(vec![
+                symbol("%plain-let"),
+                list_of(vec![list_of(vec![symbol("y"), SteelVal::CharV('y')])]),
+                symbol("y"),
+            ]),
+            SteelVal::StringV("line one\nline \"two\" \\ λ \t".into()),
+            SteelVal::CharV('\n'),
+            SteelVal::CharV(' '),
+            SteelVal::CharV('λ'),
+            SteelVal::CharV('\\'),
+            SteelVal::IntV(-42),
+            SteelVal::IntV(isize::MAX),
+            SteelVal::NumV(2.5),
+            SteelVal::NumV(-0.0),
+            SteelVal::BoolV(true),
+            SteelVal::BoolV(false),
+            SteelVal::Rational(Rational32::new(1, 3)),
+            SteelVal::BigNum(Gc::new(BigInt::from(isize::MAX) * 16)),
+            SteelVal::BigRational(Gc::new(BigRational::new(
+                BigInt::from(isize::MAX) * 4,
+                BigInt::from(3),
+            ))),
+            SteelVal::ByteVector(SteelByteVector::new(vec![0, 1, 254, 255])),
+            SteelVal::VectorV(
+                Gc::new(
+                    vec![symbol("vec-elem"), SteelVal::IntV(7)]
+                        .into_iter()
+                        .collect::<crate::values::Vector<_>>(),
+                )
+                .into(),
+            ),
+            SteelVal::Pair(Gc::new(Pair::cons(symbol("car-part"), symbol("cdr-part")))),
+            SteelVal::Void,
+        ]
+    }
+
+    #[test]
+    fn round_trip_preserves_constants() {
+        let constants = representative_constants();
+        let map = ConstantMap::from_vec(constants.clone());
+
+        let bytes = map.to_bytes().unwrap();
+        let restored = ConstantMap::from_bytes(&bytes).unwrap();
+
+        assert_eq!(restored.len(), constants.len());
+
+        for (index, expected) in constants.iter().enumerate() {
+            assert_eq!(
+                restored.try_get(index).unwrap(),
+                *expected,
+                "constant {index} did not survive the round trip"
+            );
+        }
+    }
 
     #[test]
     fn run_tests_constant_map() {

--- a/crates/steel-core/src/compiler/program.rs
+++ b/crates/steel-core/src/compiler/program.rs
@@ -3,6 +3,7 @@ use crate::core::labels::Expr;
 use crate::gc::shared::StandardShared;
 use crate::gc::Shared;
 use crate::parser::span_visitor::get_span;
+use crate::rerrs::{ErrorKind, SteelErr};
 use crate::rvals::Result;
 use crate::{
     compiler::constants::ConstantMap,
@@ -962,26 +963,42 @@ pub struct SerializableRawProgramWithSymbols {
 }
 
 impl SerializableRawProgramWithSymbols {
-    pub fn write_to_file(&self, filename: &str) -> Result<()> {
-        use std::io::prelude::*;
+    pub fn serialize_to_path(&self, path: impl AsRef<Path>) -> Result<()> {
+        let buffer = bincode::serialize(self).map_err(|e| {
+            SteelErr::new(
+                ErrorKind::Generic,
+                format!(
+                    "unable to serialize the program for {:?}: {e}",
+                    path.as_ref()
+                ),
+            )
+        })?;
 
-        let mut file = File::create(format!("{filename}.txt")).unwrap();
+        std::fs::write(path.as_ref(), buffer)?;
 
-        let buffer = bincode::serialize(self).unwrap();
-
-        file.write_all(&buffer)?;
         Ok(())
     }
 
+    pub fn deserialize_from_path(path: impl AsRef<Path>) -> Result<Self> {
+        let buffer = std::fs::read(path.as_ref())?;
+
+        bincode::deserialize(&buffer).map_err(|e| {
+            SteelErr::new(
+                ErrorKind::Generic,
+                format!(
+                    "unable to deserialize the program at {:?}: {e}",
+                    path.as_ref()
+                ),
+            )
+        })
+    }
+
+    pub fn write_to_file(&self, filename: &str) -> Result<()> {
+        self.serialize_to_path(format!("{filename}.txt"))
+    }
+
     pub fn read_from_file(filename: &str) -> Result<Self> {
-        use std::io::prelude::*;
-
-        let mut file = File::open(format!("{filename}.txt")).unwrap();
-        let mut buffer = Vec::new();
-        let _ = file.read_to_end(&mut buffer).unwrap();
-        let program: Self = bincode::deserialize(&buffer).unwrap();
-
-        Ok(program)
+        Self::deserialize_from_path(format!("{filename}.txt"))
     }
 
     pub fn into_raw_program(self) -> RawProgramWithSymbols {
@@ -1170,6 +1187,44 @@ impl RawProgramWithSymbols {
             constant_map: self.constant_map.to_bytes()?,
             version: self.version,
         })
+    }
+
+    pub(crate) fn merge_constants_into(&mut self, target: &mut ConstantMap) -> Result<()> {
+        if self.constant_map.shares_storage_with(target) {
+            return Ok(());
+        }
+
+        for expression in &mut self.instructions {
+            let mut previous_op = None;
+
+            for instruction in expression.iter_mut() {
+                let references_constant = match instruction.op_code {
+                    OpCode::PUSHCONST | OpCode::EQUALCONST => true,
+                    OpCode::PASS => matches!(
+                        previous_op,
+                        Some(OpCode::ADDREGISTER | OpCode::SUBREGISTER | OpCode::LTEREGISTER)
+                    ),
+                    _ => false,
+                };
+
+                if references_constant {
+                    let index = instruction.payload_size.to_usize();
+
+                    let Some(value) = self.constant_map.try_get(index) else {
+                        stop!(Generic => format!("deserialized program references constant index {index} which is outside of its own constant map"));
+                    };
+
+                    instruction.payload_size = u24::from_usize(target.add_or_get(value));
+                }
+
+                previous_op = Some(instruction.op_code);
+            }
+        }
+
+        target.flush();
+        self.constant_map = target.clone();
+
+        Ok(())
     }
 
     pub fn debug_print(&self) {

--- a/crates/steel-core/src/steel_vm/engine.rs
+++ b/crates/steel-core/src/steel_vm/engine.rs
@@ -826,13 +826,7 @@ impl Engine {
 
         engine.virtual_machine.compiler.write().sources = program.sources;
 
-        // TODO: The constant map needs to be brought back as well. Install it here.
-        // it needs to get installed in the VM and the compiler. Lets just try that now.
-
         let raw_program = SerializableRawProgramWithSymbols::into_raw_program(program.program);
-
-        engine.virtual_machine.constant_map = raw_program.constant_map.clone();
-        engine.virtual_machine.compiler.write().constant_map = raw_program.constant_map.clone();
 
         let results = engine.run_raw_program(raw_program);
 
@@ -1850,8 +1844,10 @@ impl Engine {
 
     pub fn raw_program_to_executable(
         &mut self,
-        program: RawProgramWithSymbols,
+        mut program: RawProgramWithSymbols,
     ) -> Result<Executable> {
+        program.merge_constants_into(&mut self.virtual_machine.compiler.write().constant_map)?;
+
         let symbol_map_offset = self.virtual_machine.compiler.read().symbol_map.len();
 
         let result = program.build(
@@ -2628,6 +2624,65 @@ mod engine_api_tests {
         assert!(engine
             .compile_and_run_raw_program("(external-get-value-imm *external*)")
             .is_err());
+    }
+}
+
+#[cfg(test)]
+mod serialized_program_tests {
+    use super::*;
+
+    const PROGRAM_SOURCE: &str = r#"
+        (define quoted-global 'quokka-constant)
+        (define literal-global 4242)
+        (define evaled-global (eval '(quote wallaby-constant)))
+    "#;
+
+    fn observable_state(engine: &mut Engine) -> (SteelVal, SteelVal, SteelVal, Vec<SteelVal>) {
+        let post_run_eval = engine
+            .compile_and_run_raw_program("(eval '(quote heron-constant))")
+            .unwrap();
+
+        (
+            engine.extract_value("quoted-global").unwrap(),
+            engine.extract_value("literal-global").unwrap(),
+            engine.extract_value("evaled-global").unwrap(),
+            post_run_eval,
+        )
+    }
+
+    #[test]
+    fn running_deserialized_program_matches_source_compiled_engine() {
+        let program_path = std::env::temp_dir().join(format!(
+            "steel-serialized-program-test-{}.bin",
+            std::process::id()
+        ));
+
+        let mut emitting_engine = Engine::new();
+        emitting_engine
+            .emit_raw_program_no_path(PROGRAM_SOURCE)
+            .unwrap()
+            .into_serializable_program()
+            .unwrap()
+            .serialize_to_path(&program_path)
+            .unwrap();
+
+        let mut deserializing_engine = Engine::new();
+        let deserialized =
+            SerializableRawProgramWithSymbols::deserialize_from_path(&program_path).unwrap();
+        std::fs::remove_file(&program_path).unwrap();
+        deserializing_engine
+            .run_raw_program(deserialized.into_raw_program())
+            .unwrap();
+
+        let mut source_engine = Engine::new();
+        source_engine
+            .compile_and_run_raw_program(PROGRAM_SOURCE)
+            .unwrap();
+
+        assert_eq!(
+            observable_state(&mut deserializing_engine),
+            observable_state(&mut source_engine)
+        );
     }
 }
 


### PR DESCRIPTION
Found these while building startup caching for the [nothelix plugin](https://github.com/koalazub/nothelix) on the [helix fork](https://github.com/koalazub/helix) that I use. We compile the whole plugin as one RawProgramWithSymbols, serialise it to disk, and run it from the artifact on later launches so the editor doesn't recompile ~9k lines of scheme every start at this pint of writing.

Two things came up on that path.

Running a deserialised program installs its constant map as the VM's live table while Compiler::constant_map stays separate. The program itself runs fine, but any eval afterwards compiles constant indices against the compiler's map and resolves them in the program's map, so you get FreeIdentifier or the wrong literal back. The fix rebases a detached program onto the compiler's live map in raw_program_to_executable (add_or_get and rewriting the constant referencing payloads), and drops the map swap in execute_non_interactive_program_image since it's covered by the same path now.

ConstantMap's to_bytes/from_bytes went through display strings and a reparse, which re-lowers on the way back in. (quote x) came back as x and let forms came back as lambdas, so a round trip changed the program.

note: merge_constants_into has to know which opcodes reference constants (PUSHCONST, EQUALCONST and the register PASS variants). I checked the list against the current vm.rs but it's the kind of thing that could rot quietly if new opcodes land. Happy to restructure if you'd rather that knowledge live somewhere else.
