### PR TITLE
allow negative values in isize argument conversion

### DIFF
--- a/crates/steel-core/src/steel_vm/ffi.rs
+++ b/crates/steel-core/src/steel_vm/ffi.rs
@@ -472,11 +472,7 @@ impl<'a> FromFFIArg<'a> for usize {
 impl<'a> FromFFIArg<'a> for isize {
     fn from_ffi_arg(val: FFIArg<'a>) -> RResult<Self, RBoxError> {
         if let FFIArg::IntV(i) = val {
-            if i < 0 {
-                conversion_error!(isize, val)
-            } else {
-                RResult::ROk(i as isize)
-            }
+            RResult::ROk(i as isize)
         } else {
             conversion_error!(isize, val)
         }


### PR DESCRIPTION
When making a rust function for the steel library, a function that acceps an isize argument only allows positive values because the 
```rust
impl<'a> FromFFIArg<'a> for isize 
```
returns an error if the value is below 0, identical to how usize argument conversion works.
This pull request fixes that, allowing isize arguments to be below 0.