### PR TITLE
forge: drop args correctly on windows

### DIFF
--- a/crates/forge/installer/main.scm
+++ b/crates/forge/installer/main.scm
@@ -233,8 +233,9 @@ Commands:
 
 (define (get-command-line-args)
   (define args (command-line))
+  (define interpreter (if (equal? (current-os!) "windows") "steel.exe" "steel"))
   ;; Running as a program, vs embedded elsewhere?
-  (if (ends-with? (car args) "steel")
+  (if (ends-with? (car args) interpreter)
       (drop args 2)
       (drop args 1)))
 


### PR DESCRIPTION
This PR fixes a small bug where args are not dropped when running forge as a standalone script on Windows with `steel forge.scm`, as the interpreter has the .exe extension.